### PR TITLE
Add support for accessing App.config also in iOS project

### DIFF
--- a/src/Vahti.Mobile/Vahti.Mobile.iOS/AppDelegate.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.iOS/AppDelegate.cs
@@ -3,6 +3,7 @@ using Foundation;
 using Vahti.Mobile.Forms.Theme;
 using UIKit;
 using Vahti.Mobile.Forms;
+using PCLAppConfig;
 
 namespace Vahti.Mobile.iOS
 {
@@ -29,6 +30,8 @@ namespace Vahti.Mobile.iOS
             global::Xamarin.Forms.Forms.SetFlags("Shell_Experimental", "Visual_Experimental", "CollectionView_Experimental", "FastRenderers_Experimental");
             global::Xamarin.Forms.Forms.Init();
             OxyPlot.Xamarin.Forms.Platform.iOS.PlotViewRenderer.Init();
+
+            ConfigurationManager.Initialise(PCLAppConfig.FileSystemStream.PortableStream.Current);
             LoadApplication(new App(this));
 
             return base.FinishedLaunching(app, options);

--- a/src/Vahti.Mobile/Vahti.Mobile.iOS/Vahti.Mobile.iOS.csproj
+++ b/src/Vahti.Mobile/Vahti.Mobile.iOS/Vahti.Mobile.iOS.csproj
@@ -97,6 +97,9 @@
     <Compile Include="Localize.cs" />
     <Compile Include="Renderers\GradientColorStackLayoutRenderer.cs" />
     <Compile Include="Renderers\GradientColorGridRenderer.cs" />
+    <None Include="..\Vahti.Mobile.Forms\App.config">
+      <Link>App.config</Link>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
@@ -183,7 +186,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Vahti.Mobile.Forms\Vahti.Mobile.Forms.csproj">
-      <Project>{3ED07C76-F6A4-4163-B892-852510B44DA5}</Project>
+      <Project>{45E2C9BF-558D-4F2D-8E9F-19DB7C5CC0E5}</Project>
       <Name>Vahti.Mobile.Forms</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Adds link to App.config in iOS project and initializes `PCLAppConfig` in `AppDelegate`. This allows accessing App.config. There are still plenty of issues in iOS app, but this allows app at least to start up.

Fixes #3 