### PR TITLE
DataBrokerService to send alerts also if cloud publishing is disabled

### DIFF
--- a/src/Vahti.DataBroker/DataBrokerService.cs
+++ b/src/Vahti.DataBroker/DataBrokerService.cs
@@ -75,8 +75,7 @@ namespace Vahti.DataBroker
                     {
                         if (minuteCounter % _config.CloudPublishConfiguration.UpdateIntervalMinutes == 0)
                         {
-                            await _dataBroker.PublishCurrentData();
-                            await _dataBroker.SendAlerts();
+                            await _dataBroker.PublishCurrentData();                            
                         }
 
                         if (minuteCounter % _config.CloudPublishConfiguration.HistoryUpdateIntervalMinutes == 0)
@@ -88,7 +87,9 @@ namespace Vahti.DataBroker
                         {
                             await _dataBroker.DeleteOldHistoryData();
                         }
-                    }                    
+                    }
+
+                    await _dataBroker.SendAlerts();
 
                     await Task.Delay(TimeSpan.FromSeconds(LoopInterval), stoppingToken);
                     minuteCounter++;


### PR DESCRIPTION
One line fix to change alert sending so, that alerts are sent regardless of if cloud publishing is enabled or not. Alert functionality is not dependent of cloud.

Fixes #5 