### PR TITLE
Separate device specific sensor reading code to separate class

### DIFF
--- a/src/Vahti.Collector.Test/DeviceScanner/DeviceScannerTests.cs
+++ b/src/Vahti.Collector.Test/DeviceScanner/DeviceScannerTests.cs
@@ -1,0 +1,577 @@
+﻿using BleReaderNet.Reader;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Vahti.Collector.Configuration;
+using Vahti.Collector.DeviceDataReader;
+using Vahti.Shared.Data;
+using Vahti.Shared.TypeData;
+
+namespace Vahti.Collector.Test.DeviceScanner
+{
+    /// <Summary>
+    /// Unit tests for <see cref="CollectorService"/>
+    /// </Summary>
+    [TestClass]
+    public class DeviceScannerTests
+    {
+        private Mock<ILogger<Collector.DeviceScanner.DeviceScanner>> _loggerMock;
+        private Mock<IOptions<CollectorConfiguration>> _configMock;
+        private Mock<IBleReader> _bleReaderMock;
+        private Mock<IDeviceDataReader> _dataReaderMock;
+        private ServiceProvider _serviceProvider;
+
+        [TestInitialize]
+        public void InitializeTest()
+        {
+            _loggerMock = new Mock<ILogger<Collector.DeviceScanner.DeviceScanner>>();
+            _configMock = new Mock<IOptions<CollectorConfiguration>>();
+            _dataReaderMock = new Mock<IDeviceDataReader>();
+            _bleReaderMock = new Mock<IBleReader>();
+            
+            var services = new ServiceCollection();
+            services.AddSingleton<Collector.DeviceScanner.DeviceScanner>();
+            services.AddSingleton(l => _loggerMock.Object);
+            services.AddSingleton(c => _configMock.Object);
+            services.AddSingleton(d => _dataReaderMock.Object);
+            services.AddSingleton(d => _bleReaderMock.Object);
+
+            _serviceProvider = services.BuildServiceProvider();
+        }
+
+        /// <summary>
+        /// Tests the basic loop handling so that correct amount of measurements is returned for devices/measurements 
+        /// and returned data is correct
+        /// </summary>
+        /// <param name="sensorDeviceCount">Amount of sensor devices</param>
+        /// <param name="measurementCount">Amount of measurements</param>        
+        [TestMethod]
+        [DataRow(0, 0)]
+        [DataRow(1, 0)]
+        [DataRow(0, 1)]
+        [DataRow(1, 1)]
+        [DataRow(2, 1)]
+        [DataRow(1, 2)]
+        [DataRow(2, 2)]
+        public async Task GetDeviceDataAsync_DataReturned_True(int sensorDeviceCount, int measurementCount)
+        {
+            var sensorDevices = new List<SensorDevice>();
+            var sensorDeviceTypes = new List<SensorDeviceType>();
+            var measurementList = new Dictionary<string, List<MeasurementData>>();
+
+            // Arrange
+            for (int i=1; i<=sensorDeviceCount; i++)
+            {
+                sensorDevices.Add(new SensorDevice()
+                {
+                    Id = $"Device{i}",
+                    SensorDeviceTypeId = $"DeviceType{i}"
+                });
+
+                sensorDeviceTypes.Add(new SensorDeviceType()
+                {
+                    Id = $"DeviceType{i}",
+                    Sensors = new List<Sensor>() {
+                        new Sensor(){
+                            Id = $"Sensor{i}",
+                        }
+                    }
+                });
+            }
+            var measurementTimestampBaseTicks = 1434135153;
+            var measurementValueBase = "123";
+
+            foreach (var sensorDevice in sensorDevices)
+            {
+                var list = new List<MeasurementData>();
+
+                for (int i = 1; i <= measurementCount; i++)
+                {
+                    list.Add(new MeasurementData()
+                    {
+                        SensorDeviceId = sensorDevice.Id,
+                        SensorId = sensorDeviceTypes.First(s => s.Id.Equals(sensorDevice.SensorDeviceTypeId)).Sensors[0].Id,
+                        Timestamp = new DateTime(measurementTimestampBaseTicks + i),
+                        Value = $"{measurementValueBase}{i}"
+                    });
+                }
+                measurementList.Add(sensorDevice.Id, list);
+            }                
+
+            var config = new CollectorConfiguration
+            {
+                CollectorEnabled = true,
+                BluetoothAdapterName = "test",
+                ScanIntervalSeconds = 0,
+                SensorDevices = sensorDevices,
+                SensorDeviceTypes = sensorDeviceTypes
+            };        
+            
+            
+            _configMock.Setup(c => c.Value).Returns(config);
+            _dataReaderMock.Setup(d => d.ReadDeviceDataAsync(It.IsAny<SensorDevice>()))
+                .ReturnsAsync((SensorDevice p) => measurementList[p.Id]);
+
+            var deviceScanner = _serviceProvider.GetService<Collector.DeviceScanner.DeviceScanner>();
+
+            //Act      
+            var fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+
+            // Assert
+            Assert.AreEqual(sensorDeviceCount * measurementCount, fullList.Count, "Measurement count does not match");
+
+            foreach (var sensorDevice in sensorDevices)
+            {
+                var list = new List<MeasurementData>();
+
+                for (int i = 1; i <= measurementCount; i++)
+                {
+                    Assert.IsTrue(fullList.Any(m =>
+                        m.SensorDeviceId.Equals(sensorDevice.Id) &&
+                        m.SensorId.Equals(sensorDeviceTypes.First(s => s.Id.Equals(sensorDevice.SensorDeviceTypeId)).Sensors[0].Id) &&
+                        m.Timestamp.Ticks == measurementTimestampBaseTicks + i &&
+                        m.Value.Equals($"{measurementValueBase}{i}")
+                        ));
+                }                
+            }
+        }        
+
+        /// <summary>
+        /// Tests that Bluetooth scan is not made if no Bluetooth devices exist
+        /// </summary>        
+        [TestMethod]        
+        public async Task GetDeviceDataAsync_NoBluetoothDevices_NoScanMade()
+        {
+            var sensorDeviceTypeId = "SomeSensorType";
+
+            // Arrange
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = sensorDeviceTypeId,
+                Id = "SensorDevice1"
+            };
+
+            var sensorDeviceType = new SensorDeviceType()
+            {
+                Id = sensorDeviceTypeId,
+                Sensors = new List<Sensor>() {
+                        new Sensor(){
+                            Id = "Sensor1",
+                        }
+                    }
+            };
+            _dataReaderMock.Setup(d => d.ReadDeviceDataAsync(It.IsAny<SensorDevice>()))
+                .ReturnsAsync(new List<MeasurementData>());
+
+            var config = new CollectorConfiguration
+            {
+                CollectorEnabled = true,
+                BluetoothAdapterName = "test",
+                ScanIntervalSeconds = 1,
+                SensorDevices = new List<SensorDevice>() { sensorDevice },
+                SensorDeviceTypes = new List<SensorDeviceType>() { sensorDeviceType }
+            };
+
+            _configMock.Setup(c => c.Value).Returns(config);
+            
+            var deviceScanner = _serviceProvider.GetService<Collector.DeviceScanner.DeviceScanner>();
+
+            // Act      
+            var fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+
+            // Assert 
+            _bleReaderMock.Verify(b => b.ScanAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never, 
+                "Bluetooth scan should not be made when it's not needed");
+        }
+
+        /// <summary>
+        /// Tests that Bluetooth scan is made if Bluetooth devices exist
+        /// </summary>        
+        [TestMethod]
+        public async Task GetDeviceDataAsync_BluetoothDevices_ScanMade()
+        {
+            var sensorDeviceTypeId = "RuuviTag";
+
+            // Arrange
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = sensorDeviceTypeId,
+                Id = "SensorDevice1"
+            };
+
+            var sensorDeviceType = new SensorDeviceType()
+            {
+                Id = sensorDeviceTypeId,
+                Sensors = new List<Sensor>() {
+                        new Sensor(){
+                            Id = "Sensor1",
+                        }
+                    }
+            };
+            _dataReaderMock.Setup(d => d.ReadDeviceDataAsync(It.IsAny<SensorDevice>()))
+                .ReturnsAsync(new List<MeasurementData>());
+
+            var config = new CollectorConfiguration
+            {
+                CollectorEnabled = true,
+                BluetoothAdapterName = "test",
+                ScanIntervalSeconds = 1,
+                SensorDevices = new List<SensorDevice>() { sensorDevice },
+                SensorDeviceTypes = new List<SensorDeviceType>() { sensorDeviceType }
+            };
+
+            _configMock.Setup(c => c.Value).Returns(config);
+
+            var deviceScanner = _serviceProvider.GetService<Collector.DeviceScanner.DeviceScanner>();
+
+            // Act      
+            var fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+
+            // Assert 
+            _bleReaderMock.Verify(b => b.ScanAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Once,
+                "Bluetooth scan should've been made");
+        }
+
+        /// <summary>
+        /// Tests that custom measurement data is not returned if target sensor is not found
+        /// </summary>        
+        [TestMethod]        
+        public async Task GetDeviceDataAsync_CustomMeasurementSensorNotExists_ReturnNull()
+        {
+            var sensorDeviceTypeId = "SomeSensorType";
+            var sensorDeviceId = "SomeSensorDevice";
+            var sensorId = "SomeSensor";
+            var customRule = new CustomMeasurementRule()
+            {
+                Class = "MyClass",
+                Id = "MyId",
+                Name = "My custom measurement",
+                Unit = "qwerty",
+                Operator = Shared.Enum.OperatorType.IsGreaterThan,
+                SensorId = "UnknownSensor",
+                Type = Shared.Enum.ValueType.Default,
+                Value = "somevalue"
+            };
+
+            // Arrange
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = sensorDeviceTypeId,
+                Id = sensorDeviceId,
+                CalculatedMeasurements = new List<CustomMeasurementRule>()
+                {
+                    customRule
+                }
+            };
+
+            var sensorDeviceType = new SensorDeviceType()
+            {
+                Id = sensorDeviceTypeId,
+                Sensors = new List<Sensor>() {
+                        new Sensor(){
+                            Id = sensorId,
+                        }
+                    }
+            };
+            _dataReaderMock.Setup(d => d.ReadDeviceDataAsync(It.IsAny<SensorDevice>()))
+                .ReturnsAsync(new List<MeasurementData>() { new MeasurementData()
+                {
+                    SensorDeviceId = sensorDeviceId,
+                    SensorId = sensorId,
+                    Value = "some value"
+                }});
+
+            var config = new CollectorConfiguration
+            {
+                CollectorEnabled = true,
+                BluetoothAdapterName = "test",
+                ScanIntervalSeconds = 1,
+                SensorDevices = new List<SensorDevice>() { sensorDevice },
+                SensorDeviceTypes = new List<SensorDeviceType>() { sensorDeviceType }
+            };
+
+            _configMock.Setup(c => c.Value).Returns(config);
+
+            var deviceScanner = _serviceProvider.GetService<Collector.DeviceScanner.DeviceScanner>();
+
+            // Act      
+            var fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+
+            // Assert 
+            Assert.AreEqual(1, fullList.Count, "Amount of measurements is not correct");
+            Assert.AreEqual(sensorDeviceId, fullList[0].SensorDeviceId, "Sensor device ID is not correct");
+        }
+
+        /// <summary>
+        /// Tests that custom measurement data is returned correctly for with default comparison type
+        /// </summary>        
+        [TestMethod]
+        [DataRow(Shared.Enum.OperatorType.IsGreaterThan, "1.23", "0.66", true)]
+        [DataRow(Shared.Enum.OperatorType.IsGreaterThan, "0.44", "0.66", false)]
+        [DataRow(Shared.Enum.OperatorType.IsLessThan, "1.23", "0.66", false)]
+        [DataRow(Shared.Enum.OperatorType.IsLessThan, "1.23", "1.88", true)]
+        [DataRow(Shared.Enum.OperatorType.IsEqualTo, "66", "66", true)]
+        [DataRow(Shared.Enum.OperatorType.IsEqualTo, "66", "68", false)]
+        public async Task GetDeviceDataAsync_DefaultTypeCustomMeasurementExists_Returned(Shared.Enum.OperatorType operatorType,
+            string measurementValue, string customRuleValue, bool expectedValue)
+        {
+            var sensorDeviceTypeId = "SomeSensorType";
+            var sensorDeviceId = "SomeSensorDevice";
+            var sensorId = "SomeSensor";            
+            var customRule = new CustomMeasurementRule()
+            {
+                Class = "MyClass",
+                Id = "MyId",
+                Name = "My custom measurement",
+                Unit = "qwerty",
+                Operator = operatorType,
+                SensorId = sensorId,
+                Type = Shared.Enum.ValueType.Default,
+                Value = customRuleValue
+            };
+
+            // Arrange
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = sensorDeviceTypeId,
+                Id = sensorDeviceId,
+                CalculatedMeasurements = new List<CustomMeasurementRule>()
+                {
+                    customRule
+                }
+            };
+
+            var sensorDeviceType = new SensorDeviceType()
+            {
+                Id = sensorDeviceTypeId,
+                Sensors = new List<Sensor>() {
+                        new Sensor(){
+                            Id = sensorId,
+                        }
+                    }
+            };
+            _dataReaderMock.Setup(d => d.ReadDeviceDataAsync(It.IsAny<SensorDevice>()))
+                .ReturnsAsync(new List<MeasurementData>() { new MeasurementData()
+                {
+                    SensorDeviceId = sensorDeviceId,
+                    SensorId = sensorId,
+                    Value = measurementValue
+                }});
+
+            var config = new CollectorConfiguration
+            {
+                CollectorEnabled = true,
+                BluetoothAdapterName = "test",
+                ScanIntervalSeconds = 1,
+                SensorDevices = new List<SensorDevice>() { sensorDevice },
+                SensorDeviceTypes = new List<SensorDeviceType>() { sensorDeviceType }
+            };
+
+            _configMock.Setup(c => c.Value).Returns(config);
+
+            var deviceScanner = _serviceProvider.GetService<Collector.DeviceScanner.DeviceScanner>();
+
+            // Act      
+            var fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+
+            // Assert 
+            Assert.AreEqual(2, fullList.Count, "Amount of measurements is not correct");
+
+            var customMeasurement = fullList.First(f => f.SensorId.Equals(customRule.Id, StringComparison.OrdinalIgnoreCase));
+            Assert.AreEqual(sensorDeviceId, customMeasurement.SensorDeviceId, "Sensor device ID does not match");
+            Assert.AreNotEqual(default(DateTime), customMeasurement.Timestamp, "Timestamp has not been set");
+            Assert.AreEqual(expectedValue, bool.Parse(customMeasurement.Value), "Value is not what expected");
+        }
+
+        /// <summary>
+        /// Tests that custom measurement data is returned correctly for with ´WasLast' comparison type
+        /// </summary>        
+        [TestMethod]
+        [DataRow(Shared.Enum.OperatorType.IsGreaterThan, "1.23", "0.66", "0")]
+        [DataRow(Shared.Enum.OperatorType.IsGreaterThan, "0.44", "0.66", "-1")]
+        [DataRow(Shared.Enum.OperatorType.IsLessThan, "0.33", "0.66", "0")]
+        [DataRow(Shared.Enum.OperatorType.IsLessThan, "1.1", "0.66", "-1")]
+        [DataRow(Shared.Enum.OperatorType.IsEqualTo, "4", "4", "0")]
+        [DataRow(Shared.Enum.OperatorType.IsEqualTo, "5", "8", "-1")]
+        public async Task GetDeviceDataAsync_WasLastTypeCustomMeasurementExists_HandleValueZeroAndMinusOne(
+            Shared.Enum.OperatorType operatorType, string measurementValue, string customRuleValue, string expectedComparisonValue)
+        {
+            var sensorDeviceTypeId = "SomeSensorType";
+            var sensorDeviceId = "SomeSensorDevice";
+            var sensorId = "SomeSensor";
+            var customRule = new CustomMeasurementRule()
+            {
+                Class = "MyClass",
+                Id = "MyId",
+                Name = "My custom measurement",
+                Unit = "qwerty",
+                Operator = operatorType,
+                SensorId = sensorId,
+                Type = Shared.Enum.ValueType.WasLast,
+                Value = customRuleValue
+            };
+
+            // Arrange
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = sensorDeviceTypeId,
+                Id = sensorDeviceId,
+                CalculatedMeasurements = new List<CustomMeasurementRule>()
+                {
+                    customRule
+                }
+            };
+
+            var sensorDeviceType = new SensorDeviceType()
+            {
+                Id = sensorDeviceTypeId,
+                Sensors = new List<Sensor>() {
+                        new Sensor(){
+                            Id = sensorId,
+                        }
+                    }
+            };
+            _dataReaderMock.Setup(d => d.ReadDeviceDataAsync(It.IsAny<SensorDevice>()))               
+                .ReturnsAsync(new List<MeasurementData>() { new MeasurementData()
+                {
+                    SensorDeviceId = sensorDeviceId,
+                    SensorId = sensorId,
+                    Value = measurementValue
+                }})
+                ;
+
+            var config = new CollectorConfiguration
+            {
+                CollectorEnabled = true,
+                BluetoothAdapterName = "test",
+                ScanIntervalSeconds = 1,
+                SensorDevices = new List<SensorDevice>() { sensorDevice },
+                SensorDeviceTypes = new List<SensorDeviceType>() { sensorDeviceType }
+            };
+
+            _configMock.Setup(c => c.Value).Returns(config);
+
+            var deviceScanner = _serviceProvider.GetService<Collector.DeviceScanner.DeviceScanner>();
+
+            // Act      
+            var fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+
+            // Assert 
+            Assert.AreEqual(2, fullList.Count, "Amount of measurements is not correct");
+            
+            var customMeasurement = fullList.First(f => f.SensorId.Equals(customRule.Id, StringComparison.OrdinalIgnoreCase));
+            Assert.AreEqual(sensorDeviceId, customMeasurement.SensorDeviceId, "Sensor device ID does not match");
+            Assert.AreNotEqual(default(DateTime), customMeasurement.Timestamp, "Timestamp has not been set");
+            Assert.AreEqual(expectedComparisonValue, customMeasurement.Value, "Value is not what expected");
+        }
+
+        /// <summary>
+        /// Tests that custom measurement data is returned correctly for with 'WasLast' type with sequence:
+        /// Condition false -> condition true -> condition false -> condition true
+        /// </summary>        
+        [TestMethod]        
+        public async Task GetDeviceDataAsync_WasLastTypeCustomMeasurement_SequenceWorksCorrectly()
+        {
+            var sensorDeviceTypeId = "SomeSensorType";
+            var sensorDeviceId = "SomeSensorDevice";
+            var sensorId = "SomeSensor";
+            var customRule = new CustomMeasurementRule()
+            {
+                Class = "MyClass",
+                Id = "MyId",
+                Name = "My custom measurement",
+                Unit = "qwerty",
+                Operator = Shared.Enum.OperatorType.IsGreaterThan,
+                SensorId = sensorId,
+                Type = Shared.Enum.ValueType.WasLast,
+                Value = "1.66"
+            };
+
+            // Arrange
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = sensorDeviceTypeId,
+                Id = sensorDeviceId,
+                CalculatedMeasurements = new List<CustomMeasurementRule>()
+                {
+                    customRule
+                }
+            };
+
+            var sensorDeviceType = new SensorDeviceType()
+            {
+                Id = sensorDeviceTypeId,
+                Sensors = new List<Sensor>() {
+                        new Sensor(){
+                            Id = sensorId,
+                        }
+                    }
+            };
+            _dataReaderMock.SetupSequence(d => d.ReadDeviceDataAsync(It.IsAny<SensorDevice>()))
+                .ReturnsAsync(new List<MeasurementData>() { new MeasurementData()
+                {
+                    SensorDeviceId = sensorDeviceId,
+                    SensorId = sensorId,
+                    Value = "0.1"
+                }})
+                .ReturnsAsync(new List<MeasurementData>() { new MeasurementData()
+                {
+                    SensorDeviceId = sensorDeviceId,
+                    SensorId = sensorId,
+                    Value = "2.1"
+                }})
+                .ReturnsAsync(new List<MeasurementData>() { new MeasurementData()
+                {
+                    SensorDeviceId = sensorDeviceId,
+                    SensorId = sensorId,
+                    Value = "0.1"
+                }})
+                .ReturnsAsync(new List<MeasurementData>() { new MeasurementData()
+                {
+                    SensorDeviceId = sensorDeviceId,
+                    SensorId = sensorId,
+                    Value = "2.1"
+                }})
+                ;
+
+            var config = new CollectorConfiguration
+            {
+                CollectorEnabled = true,
+                BluetoothAdapterName = "test",
+                ScanIntervalSeconds = 1,
+                SensorDevices = new List<SensorDevice>() { sensorDevice },
+                SensorDeviceTypes = new List<SensorDeviceType>() { sensorDeviceType }
+            };
+
+            _configMock.Setup(c => c.Value).Returns(config);
+
+            var deviceScanner = _serviceProvider.GetService<Collector.DeviceScanner.DeviceScanner>();
+
+            // Act      
+            var fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices); 
+            var customMeasurement = fullList.First(f => f.SensorId.Equals(customRule.Id, StringComparison.OrdinalIgnoreCase));            
+            Assert.AreEqual("-1", customMeasurement.Value, "Value is not what expected when condition has not been true yet");
+
+            fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+            customMeasurement = fullList.First(f => f.SensorId.Equals(customRule.Id, StringComparison.OrdinalIgnoreCase));
+            Assert.AreEqual("0", customMeasurement.Value, "Value is not what expected when condition became true");
+
+            // Wait more than one second to get "WasLast" value to get updated to 1
+            await Task.Delay(1200);
+
+            fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+            customMeasurement = fullList.First(f => f.SensorId.Equals(customRule.Id, StringComparison.OrdinalIgnoreCase));
+            Assert.AreEqual("1", customMeasurement.Value, "Value is not what expected when condition became false again");
+
+            fullList = await deviceScanner.GetDeviceDataAsync(config.SensorDevices);
+            customMeasurement = fullList.First(f => f.SensorId.Equals(customRule.Id, StringComparison.OrdinalIgnoreCase));
+            Assert.AreEqual("0", customMeasurement.Value, "Value is not what expected when condition is true again");
+        }
+    }
+}

--- a/src/Vahti.Collector/DeviceDataReader/DeviceDataReader.cs
+++ b/src/Vahti.Collector/DeviceDataReader/DeviceDataReader.cs
@@ -1,0 +1,101 @@
+﻿using BleReaderNet.Device;
+using BleReaderNet.Reader;
+using Iot.Device.DHTxx;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Device.Gpio;
+using System.Globalization;
+using System.Threading.Tasks;
+using Vahti.Shared.Data;
+using Vahti.Shared.TypeData;
+
+namespace Vahti.Collector.DeviceDataReader
+{
+    /// <summary>
+    /// Handle device specific data and returns it as <see cref="MeasurementData"/>
+    /// </summary>
+    public class DeviceDataReader : IDeviceDataReader
+    {
+        private readonly NumberFormatInfo _numberFormatInfo = new NumberFormatInfo() { NumberDecimalSeparator = "." };
+        private readonly IBleReader _bleReader;        
+        private readonly ILogger<DeviceDataReader> _logger;        
+        
+        public DeviceDataReader(ILogger<DeviceDataReader> logger, IBleReader bleReader)
+        {
+            _bleReader = bleReader;            
+            _logger = logger;            
+        }
+
+        public async Task<IList<MeasurementData>> ReadDeviceData(SensorDevice sensorDevice)
+        {
+            var measurements = new List<MeasurementData>();
+
+            switch (sensorDevice.SensorDeviceTypeId)
+            {
+                case Type.SensorDeviceTypeId.RuuviTag:
+                    measurements.AddRange(await GetRuuviTagMeasurements(sensorDevice));
+                    break;
+                case Type.SensorDeviceTypeId.Dht22:
+                    measurements.AddRange(GetDht22Measurements(sensorDevice));
+                    break;
+                // Add handlers for other device types here                
+                default:
+                    _logger.LogError($"Type of device at {sensorDevice.Address} is not supported. " +
+                        "Please check that it's been correctly defined in 'sensordevicetype' section of the configuration file");
+                    break;
+            }
+            return measurements;
+        }
+
+        private async Task<IList<MeasurementData>> GetRuuviTagMeasurements(SensorDevice sensorDevice)
+        {
+            var measurements = new List<MeasurementData>();
+
+            var ruuviData = await _bleReader.GetManufacturerDataAsync<RuuviTag>(sensorDevice.Address);
+
+            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "temperature", Value = ruuviData.Temperature.Value.ToString(_numberFormatInfo) });
+            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "humidity", Value = ruuviData.Humidity.Value.ToString(_numberFormatInfo) });
+            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "pressure", Value = ruuviData.AirPressure.Value.ToString(_numberFormatInfo) });
+
+            if (ruuviData.AccelerationX != null)
+                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationX", Value = ruuviData.AccelerationX.Value.ToString(_numberFormatInfo) });
+            if (ruuviData.AccelerationY != null)
+                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationY", Value = ruuviData.AccelerationY.Value.ToString(_numberFormatInfo) });
+            if (ruuviData.AccelerationZ != null)
+                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationZ", Value = ruuviData.AccelerationZ.Value.ToString(_numberFormatInfo) });
+            if (ruuviData.BatteryVoltage != null)
+                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "batteryVoltage", Value = ruuviData.BatteryVoltage.Value.ToString(_numberFormatInfo) });
+            if (ruuviData.MovementCounter != null)
+                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "movementCounter", Value = ruuviData.MovementCounter.Value.ToString(_numberFormatInfo) });
+
+            return measurements;
+        }
+
+        /// <summary>
+        /// Read values from DHT22 sensor. It seems that the Dht22 support in Iot.Device.Bindings does not work very well, 
+        /// but this can be considered as example on how to easily add support for additional devices
+        /// </summary>        
+        private IList<MeasurementData> GetDht22Measurements(SensorDevice sensorDevice)
+        {
+            var measurements = new List<MeasurementData>();
+
+            var pinNumber = int.Parse(sensorDevice.Address);
+
+            using (var dht22 = new Dht22(pinNumber, PinNumberingScheme.Logical))
+            {
+                if (dht22.IsLastReadSuccessful)
+                {
+                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "temperature", Value = dht22.Temperature.Celsius.ToString(_numberFormatInfo) });
+                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "humidity", Value = dht22.Temperature.Celsius.ToString(_numberFormatInfo) });
+                }
+                else
+                {
+                    _logger.LogWarning($"{DateTime.Now}: Could not read data from {sensorDevice.Id}");
+                }
+            }
+
+            return measurements;
+        }
+    }
+}

--- a/src/Vahti.Collector/DeviceDataReader/DeviceDataReader.cs
+++ b/src/Vahti.Collector/DeviceDataReader/DeviceDataReader.cs
@@ -27,14 +27,14 @@ namespace Vahti.Collector.DeviceDataReader
             _logger = logger;            
         }
 
-        public async Task<IList<MeasurementData>> ReadDeviceData(SensorDevice sensorDevice)
+        public async Task<IList<MeasurementData>> ReadDeviceDataAsync(SensorDevice sensorDevice)
         {
             var measurements = new List<MeasurementData>();
 
             switch (sensorDevice.SensorDeviceTypeId)
             {
                 case Type.SensorDeviceTypeId.RuuviTag:
-                    measurements.AddRange(await GetRuuviTagMeasurements(sensorDevice));
+                    measurements.AddRange(await GetRuuviTagMeasurementsAsync(sensorDevice));
                     break;
                 case Type.SensorDeviceTypeId.Dht22:
                     measurements.AddRange(GetDht22Measurements(sensorDevice));
@@ -48,7 +48,7 @@ namespace Vahti.Collector.DeviceDataReader
             return measurements;
         }
 
-        private async Task<IList<MeasurementData>> GetRuuviTagMeasurements(SensorDevice sensorDevice)
+        private async Task<IList<MeasurementData>> GetRuuviTagMeasurementsAsync(SensorDevice sensorDevice)
         {
             var measurements = new List<MeasurementData>();
 

--- a/src/Vahti.Collector/DeviceDataReader/IDeviceDataReader.cs
+++ b/src/Vahti.Collector/DeviceDataReader/IDeviceDataReader.cs
@@ -10,6 +10,6 @@ namespace Vahti.Collector.DeviceDataReader
     /// </summary>
     public interface IDeviceDataReader
     {
-        Task<IList<MeasurementData>> ReadDeviceData(SensorDevice sensorDevice);
+        Task<IList<MeasurementData>> ReadDeviceDataAsync(SensorDevice sensorDevice);
     }
 }

--- a/src/Vahti.Collector/DeviceDataReader/IDeviceDataReader.cs
+++ b/src/Vahti.Collector/DeviceDataReader/IDeviceDataReader.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Vahti.Shared.Data;
+using Vahti.Shared.TypeData;
+
+namespace Vahti.Collector.DeviceDataReader
+{
+    /// <summary>
+    /// Defines functionality to reading data from device
+    /// </summary>
+    public interface IDeviceDataReader
+    {
+        Task<IList<MeasurementData>> ReadDeviceData(SensorDevice sensorDevice);
+    }
+}

--- a/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
+++ b/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
@@ -1,16 +1,13 @@
-﻿using BleReaderNet.Device;
-using BleReaderNet.Reader;
-using Iot.Device.DHTxx;
+﻿using BleReaderNet.Reader;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Device.Gpio;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Vahti.Collector.Configuration;
+using Vahti.Collector.DeviceDataReader;
 using Vahti.Shared.Data;
 using Vahti.Shared.TypeData;
 using Vahti.Shared.Utils;
@@ -18,22 +15,24 @@ using Vahti.Shared.Utils;
 namespace Vahti.Collector.DeviceScanner
 {
     /// <summary>
-    /// Provides functionality to scan and read data from devices
+    /// Provides functionality to scan devices and handle data as generic <see cref="MeasurementData"/>
     /// </summary>
     public class DeviceScanner : IDeviceScanner
     {
         public const int DeviceScanDuration = 10;
 
         private readonly IBleReader _bleReader;
+        private readonly IDeviceDataReader _dataReader;
         private readonly ILogger<DeviceScanner> _logger;
         private readonly CollectorConfiguration _config;
         private readonly Dictionary<string, DateTime> _wasLastList = new Dictionary<string, DateTime>();
         private readonly ReadOnlyCollection<string> _bluetoothDevices = new List<string>() { Type.SensorDeviceTypeId.RuuviTag }.AsReadOnly();
-        private readonly NumberFormatInfo _numberFormatInfo = new NumberFormatInfo() { NumberDecimalSeparator = "." };
+        
 
-        public DeviceScanner(ILogger<DeviceScanner> logger, IBleReader bleReader, IOptions<CollectorConfiguration> config)
+        public DeviceScanner(ILogger<DeviceScanner> logger, IBleReader bleReader, IDeviceDataReader dataReader, IOptions<CollectorConfiguration> config)
         {
             _bleReader = bleReader;
+            _dataReader = dataReader;
             _logger = logger;
             _config = config.Value;
         }
@@ -58,20 +57,7 @@ namespace Vahti.Collector.DeviceScanner
                     bluetoothDevicesScanned = true;
                 }
 
-                switch (sensorDevice.SensorDeviceTypeId)
-                {
-                    case Type.SensorDeviceTypeId.RuuviTag:
-                        measurementsList.AddRange(await GetRuuviTagMeasurements(sensorDevice));
-                        break;
-                    case Type.SensorDeviceTypeId.Dht22:
-                        measurementsList.AddRange(GetDht22Measurements(sensorDevice));
-                        break;
-                    // Add handlers for other device types here                
-                    default:
-                        _logger.LogError($"Type of device at {sensorDevice.Address} is not supported. " +
-                            "Please check that it's been correctly defined in 'sensordevicetype' section of the configuration file");
-                        return null;
-                }
+                measurementsList.AddRange(await _dataReader.ReadDeviceData(sensorDevice));
 
                 if (sensorDevice.CalculatedMeasurements != null)
                 {
@@ -83,57 +69,7 @@ namespace Vahti.Collector.DeviceScanner
             }            
 
             return measurementsList;
-        }
-
-        private async Task<IList<MeasurementData>> GetRuuviTagMeasurements(SensorDevice sensorDevice)
-        {
-            var measurements = new List<MeasurementData>();
-
-            var ruuviData = await _bleReader.GetManufacturerDataAsync<RuuviTag>(sensorDevice.Address);
-
-            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "temperature", Value = ruuviData.Temperature.Value.ToString(_numberFormatInfo) });
-            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "humidity", Value = ruuviData.Humidity.Value.ToString(_numberFormatInfo) });
-            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "pressure", Value = ruuviData.AirPressure.Value.ToString(_numberFormatInfo) });
-
-            if (ruuviData.AccelerationX != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationX", Value = ruuviData.AccelerationX.Value.ToString(_numberFormatInfo) });
-            if (ruuviData.AccelerationY != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationY", Value = ruuviData.AccelerationY.Value.ToString(_numberFormatInfo) });
-            if (ruuviData.AccelerationZ != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationZ", Value = ruuviData.AccelerationZ.Value.ToString(_numberFormatInfo) });
-            if (ruuviData.BatteryVoltage != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "batteryVoltage", Value = ruuviData.BatteryVoltage.Value.ToString(_numberFormatInfo) });
-            if (ruuviData.MovementCounter != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "movementCounter", Value = ruuviData.MovementCounter.Value.ToString(_numberFormatInfo) });
-
-            return measurements;
-        }
-
-        /// <summary>
-        /// Read values from DHT22 sensor. It seems that the Dht22 support in Iot.Device.Bindings does not work very well, 
-        /// but this can be considered as example on how to easily add support for additional devices
-        /// </summary>        
-        private IList<MeasurementData> GetDht22Measurements(SensorDevice sensorDevice)
-        {
-            var measurements = new List<MeasurementData>();
-                        
-            var pinNumber = int.Parse(sensorDevice.Address);
-
-            using (var dht22 = new Dht22(pinNumber, PinNumberingScheme.Logical))
-            {
-                if (dht22.IsLastReadSuccessful)
-                {
-                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "temperature", Value = dht22.Temperature.Celsius.ToString(_numberFormatInfo) });
-                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "humidity", Value = dht22.Temperature.Celsius.ToString(_numberFormatInfo) });
-                }
-                else
-                {
-                    _logger.LogWarning($"{DateTime.Now}: Could not read data from {sensorDevice.Id}");
-                }
-            }           
-
-            return measurements;
-        }
+        }       
 
         private MeasurementData GetCustomMeasurementValue(SensorDevice sensorDevice, List<MeasurementData> measurements, CustomMeasurementRule rule)
         {

--- a/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
+++ b/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
@@ -81,7 +81,7 @@ namespace Vahti.Collector.DeviceScanner
                 return null;
             }
 
-            var data = new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = rule.Id };
+            var data = new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = rule.Id, Timestamp = DateTime.Now };
             var comparisonResult = LogicHelper.Compare(sensorMeasurement.Value, rule.Value, rule.Operator);
 
             switch (rule.Type)

--- a/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
+++ b/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
@@ -57,7 +57,7 @@ namespace Vahti.Collector.DeviceScanner
                     bluetoothDevicesScanned = true;
                 }
 
-                measurementsList.AddRange(await _dataReader.ReadDeviceData(sensorDevice));
+                measurementsList.AddRange(await _dataReader.ReadDeviceDataAsync(sensorDevice));
 
                 if (sensorDevice.CalculatedMeasurements != null)
                 {

--- a/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
+++ b/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
@@ -63,7 +63,12 @@ namespace Vahti.Collector.DeviceScanner
                 {
                     foreach (var customMeasurement in sensorDevice.CalculatedMeasurements)
                     {
-                        measurementsList.Add(GetCustomMeasurementValue(sensorDevice, measurementsList, customMeasurement));
+                        var customMeasurementValue = GetCustomMeasurementValue(sensorDevice, measurementsList, customMeasurement);
+
+                        if (customMeasurementValue != null)
+                        {
+                            measurementsList.Add(customMeasurementValue);
+                        }                        
                     }
                 }
             }            

--- a/src/Vahti.Server/Program.cs
+++ b/src/Vahti.Server/Program.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Vahti.Collector;
 using Vahti.Collector.Configuration;
+using Vahti.Collector.DeviceDataReader;
 using Vahti.Collector.DeviceScanner;
 using Vahti.DataBroker;
 using Vahti.DataBroker.AlertHandler;
@@ -65,6 +66,7 @@ namespace Vahti.Server
                 services.AddSingleton<IBluetoothService, DotNetBlueZService>();
                 services.AddSingleton<IBleReader, BleReader>();
                 services.AddSingleton<IDeviceScanner, DeviceScanner>();
+                services.AddSingleton<IDeviceDataReader, DeviceDataReader>();
                 services.AddTransient((p) => new MqttFactory().CreateManagedMqttClient());
                 services.AddHostedService<CollectorService>();
 


### PR DESCRIPTION
This PR moves device specific code in separate class (DeviceDataReader), which responsibility is now to read data from devices and return measurement data in generic format (MeasurementData) to caller. DeviceScanner respectively doesn't handle device specific data anymore. 

That way adding support for additional device types is more clear and safe. It improves testability too. In future the approach may need to be updated, if there will be a lot of supporter devices.

Adds also unit tests for DeviceScanner and fixes few minor issues noticed when writing tests.