### PR TITLE
Create custom measurement for correct sensor device (Vahti.Collector)

### DIFF
--- a/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
+++ b/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
@@ -78,7 +78,8 @@ namespace Vahti.Collector.DeviceScanner
 
         private MeasurementData GetCustomMeasurementValue(SensorDevice sensorDevice, List<MeasurementData> measurements, CustomMeasurementRule rule)
         {
-            var sensorMeasurement = measurements.FirstOrDefault(m => m.SensorId.Equals(rule.SensorId, StringComparison.OrdinalIgnoreCase));
+            var sensorMeasurement = measurements.FirstOrDefault(m => m.SensorId.Equals(rule.SensorId, StringComparison.OrdinalIgnoreCase) && 
+                m.SensorDeviceId.Equals(sensorDevice.Id, StringComparison.OrdinalIgnoreCase));
 
             if (sensorMeasurement == null)
             {


### PR DESCRIPTION
Currently there's no check if `SensorDeviceId` of the measurement matches with `Id` of the sensor device having the custom (calculated measurement) in `DeviceScanner.GetCustomMeasurementValue` . It leads to problems if there are multiple sensor devices with same sensor ID. Adds needed check for sensorDeviceId.