### PR TITLE
Log a warning if RuuviTag data can't be read

### DIFF
--- a/src/Vahti.Collector.Test/DeviceDataReader/DeviceDataReaderTests.cs
+++ b/src/Vahti.Collector.Test/DeviceDataReader/DeviceDataReaderTests.cs
@@ -1,0 +1,146 @@
+﻿using BleReaderNet.Device;
+using BleReaderNet.Reader;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Vahti.Shared.TypeData;
+
+namespace Vahti.Collector.Test.DeviceScanner
+{
+    /// <Summary>
+    /// Unit tests for <see cref="DeviceDataReader"/>
+    /// </Summary>
+    [TestClass]
+    public class DeviceDataReaderTests
+    {
+        private Mock<ILogger<DeviceDataReader.DeviceDataReader>> _loggerMock;        
+        private Mock<IBleReader> _bleReaderMock;        
+        private ServiceProvider _serviceProvider;
+
+        [TestInitialize]
+        public void InitializeTest()
+        {
+            _loggerMock = new Mock<ILogger<DeviceDataReader.DeviceDataReader>>();            
+            _bleReaderMock = new Mock<IBleReader>();
+            
+            var services = new ServiceCollection();
+            services.AddSingleton<DeviceDataReader.DeviceDataReader>();
+            services.AddSingleton(l => _loggerMock.Object);            
+            services.AddSingleton(d => _bleReaderMock.Object);
+
+            _serviceProvider = services.BuildServiceProvider();
+        }
+
+        /// <summary>
+        /// Tests that a warning is logged if data can't be read from RuuviTag 
+        /// </summary>        
+        [TestMethod]        
+        public async Task ReadDeviceDataAsync_RuuviTagNotFound_LogAWarning()
+        {
+            // Arrange
+            const string ruuviTagAddress = "testAddress";
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = Type.SensorDeviceTypeId.RuuviTag,
+                Id = "SensorDevice1",
+                Address = ruuviTagAddress
+            };
+
+            _bleReaderMock.Setup(b => b.GetManufacturerDataAsync<RuuviTag>(ruuviTagAddress)).ReturnsAsync(default(RuuviTag));
+            var deviceDataReader = _serviceProvider.GetService<DeviceDataReader.DeviceDataReader>();
+
+            // Act      
+            var measurementList = await deviceDataReader.ReadDeviceDataAsync(sensorDevice);
+
+            // Assert
+            Assert.AreEqual(0, measurementList.Count, "Measurement list cound should be zero");
+            _loggerMock.Verify(l => l.Log(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), 
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once, "It should have been logged that RuuviTag could not be read");            
+        }
+
+        /// <summary>
+        /// Tests that a warning is logged if data can't be read from RuuviTag 
+        /// </summary>        
+        [TestMethod]
+        public async Task ReadDeviceDataAsync_RuuviTagFound_ReturnData()
+        {
+            // Arrange
+            var numberFormatInfo = new NumberFormatInfo() { NumberDecimalSeparator = "." };
+            const string ruuviTagAddress = "testAddress";
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = Type.SensorDeviceTypeId.RuuviTag,
+                Id = "SensorDevice1",
+                Address = ruuviTagAddress
+            };
+            var ruuviTag = new RuuviTag()
+            {
+                AccelerationX = 0.123,
+                AccelerationY = 0.564,
+                AccelerationZ = -0.153,
+                AirPressure = 1060,
+                BatteryVoltage = 2.11,
+                DataFormat = 5,
+                Humidity = 77,
+                MacAddress = ruuviTagAddress,
+                MeasurementSequenceNumber = 22,
+                MovementCounter = 123,
+                Temperature = 33.3,
+                TxPower = 3
+            };
+
+            _bleReaderMock.Setup(b => b.GetManufacturerDataAsync<RuuviTag>(ruuviTagAddress)).ReturnsAsync(ruuviTag);
+            var deviceDataReader = _serviceProvider.GetService<DeviceDataReader.DeviceDataReader>();
+
+            // Act      
+            var measurementList = await deviceDataReader.ReadDeviceDataAsync(sensorDevice);
+
+            // Assert
+            Assert.AreEqual(8, measurementList.Count, "Amount of returned measurements is not correct");
+            Assert.AreEqual(ruuviTag.AccelerationX.Value.ToString(numberFormatInfo), measurementList.First(m => 
+                m.SensorId.Equals("AccelerationX", StringComparison.OrdinalIgnoreCase)).Value, "Value of AccelerationX is not correct");
+            Assert.AreEqual(ruuviTag.AccelerationY.Value.ToString(numberFormatInfo), measurementList.First(m => 
+                m.SensorId.Equals("AccelerationY", StringComparison.OrdinalIgnoreCase)).Value, "Value of AccelerationY is not correct");
+            Assert.AreEqual(ruuviTag.AccelerationZ.Value.ToString(numberFormatInfo), measurementList.First(m => 
+                m.SensorId.Equals("AccelerationZ", StringComparison.OrdinalIgnoreCase)).Value, "Value of AccelerationZ is not correct");
+            Assert.AreEqual(ruuviTag.AirPressure.Value.ToString(numberFormatInfo), measurementList.First(m => 
+                m.SensorId.Equals("Pressure", StringComparison.OrdinalIgnoreCase)).Value, "Value of Pressure is not correct");
+            Assert.AreEqual(ruuviTag.BatteryVoltage.Value.ToString(numberFormatInfo), measurementList.First(m => 
+                m.SensorId.Equals("BatteryVoltage", StringComparison.OrdinalIgnoreCase)).Value, "Value of BatteryVoltage is not correct");
+            Assert.AreEqual(ruuviTag.Humidity.Value.ToString(numberFormatInfo), measurementList.First(m => 
+                m.SensorId.Equals("Humidity", StringComparison.OrdinalIgnoreCase)).Value, "Value of Humidity is not correct");
+            Assert.AreEqual(ruuviTag.Temperature.Value.ToString(numberFormatInfo), measurementList.First(m => 
+                m.SensorId.Equals("Temperature", StringComparison.OrdinalIgnoreCase)).Value, "Value of Temperature is not correct");
+            Assert.AreEqual(ruuviTag.MovementCounter.Value.ToString(numberFormatInfo), measurementList.First(m => 
+                m.SensorId.Equals("MovementCounter", StringComparison.OrdinalIgnoreCase)).Value, "Value of MovementCounter is not correct");
+        }
+
+        /// <summary>
+        /// Tests that an error is raised if trying to read unsupported device
+        /// </summary>        
+        [TestMethod]
+        public async Task ReadDeviceDataAsync_DeviceTypeUnknown_LogAnError()
+        {
+            // Arrange            
+            var sensorDevice = new SensorDevice
+            {
+                SensorDeviceTypeId = "SomeUnsupportedDeviceType"                
+            };
+            
+            var deviceDataReader = _serviceProvider.GetService<DeviceDataReader.DeviceDataReader>();
+
+            // Act      
+            var measurementList = await deviceDataReader.ReadDeviceDataAsync(sensorDevice);
+
+            // Assert
+            Assert.AreEqual(0, measurementList.Count, "Measurement list cound should be zero");
+            _loggerMock.Verify(l => l.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once, "It should have been logged that the device type is unknown");
+        }
+    }
+}

--- a/src/Vahti.Collector/DeviceDataReader/DeviceDataReader.cs
+++ b/src/Vahti.Collector/DeviceDataReader/DeviceDataReader.cs
@@ -54,20 +54,27 @@ namespace Vahti.Collector.DeviceDataReader
 
             var ruuviData = await _bleReader.GetManufacturerDataAsync<RuuviTag>(sensorDevice.Address);
 
-            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "temperature", Value = ruuviData.Temperature.Value.ToString(_numberFormatInfo) });
-            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "humidity", Value = ruuviData.Humidity.Value.ToString(_numberFormatInfo) });
-            measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "pressure", Value = ruuviData.AirPressure.Value.ToString(_numberFormatInfo) });
+            if (ruuviData == null)
+            {
+                _logger.LogWarning($"{DateTime.Now}: Could not read manufacturer data from '{sensorDevice.Id}' at '{sensorDevice.Address}'");                
+            }
+            else
+            {
+                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "temperature", Value = ruuviData.Temperature.Value.ToString(_numberFormatInfo) });
+                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "humidity", Value = ruuviData.Humidity.Value.ToString(_numberFormatInfo) });
+                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "pressure", Value = ruuviData.AirPressure.Value.ToString(_numberFormatInfo) });
 
-            if (ruuviData.AccelerationX != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationX", Value = ruuviData.AccelerationX.Value.ToString(_numberFormatInfo) });
-            if (ruuviData.AccelerationY != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationY", Value = ruuviData.AccelerationY.Value.ToString(_numberFormatInfo) });
-            if (ruuviData.AccelerationZ != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationZ", Value = ruuviData.AccelerationZ.Value.ToString(_numberFormatInfo) });
-            if (ruuviData.BatteryVoltage != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "batteryVoltage", Value = ruuviData.BatteryVoltage.Value.ToString(_numberFormatInfo) });
-            if (ruuviData.MovementCounter != null)
-                measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "movementCounter", Value = ruuviData.MovementCounter.Value.ToString(_numberFormatInfo) });
+                if (ruuviData.AccelerationX != null)
+                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationX", Value = ruuviData.AccelerationX.Value.ToString(_numberFormatInfo) });
+                if (ruuviData.AccelerationY != null)
+                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationY", Value = ruuviData.AccelerationY.Value.ToString(_numberFormatInfo) });
+                if (ruuviData.AccelerationZ != null)
+                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "accelerationZ", Value = ruuviData.AccelerationZ.Value.ToString(_numberFormatInfo) });
+                if (ruuviData.BatteryVoltage != null)
+                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "batteryVoltage", Value = ruuviData.BatteryVoltage.Value.ToString(_numberFormatInfo) });
+                if (ruuviData.MovementCounter != null)
+                    measurements.Add(new MeasurementData() { SensorDeviceId = sensorDevice.Id, SensorId = "movementCounter", Value = ruuviData.MovementCounter.Value.ToString(_numberFormatInfo) });
+            }            
 
             return measurements;
         }

--- a/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
+++ b/src/Vahti.Collector/DeviceScanner/DeviceScanner.cs
@@ -57,9 +57,10 @@ namespace Vahti.Collector.DeviceScanner
                     bluetoothDevicesScanned = true;
                 }
 
-                measurementsList.AddRange(await _dataReader.ReadDeviceDataAsync(sensorDevice));
+                var deviceMeasurements = await _dataReader.ReadDeviceDataAsync(sensorDevice);
+                measurementsList.AddRange(deviceMeasurements);
 
-                if (sensorDevice.CalculatedMeasurements != null)
+                if (sensorDevice.CalculatedMeasurements != null && deviceMeasurements.Count > 0)
                 {
                     foreach (var customMeasurement in sensorDevice.CalculatedMeasurements)
                     {


### PR DESCRIPTION
`RuuviTag` being inaccessible (for reason or another) was unhandled, which lead to `NullReferenceException` in `DeviceDataReader`. Now a warning is logged if `BleReader.GetManufacturerDataAsync` returns null. 

DeviceScanner respectively now skips custom measurement calculation if there is no measurement data available for that sensor device.

This PR also adds basic unit tests for DeviceDataReader.