### PR TITLE
Show graph properly also if all values (y-axis) are same

### DIFF
--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Models/GraphModel.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Models/GraphModel.cs
@@ -34,8 +34,17 @@ namespace Vahti.Mobile.Forms.Models
             var ls = new AreaSeries() { DataFieldX = "X", DataFieldY = "Y", ItemsSource = graphDataPoints };
             plotModel.Series.Add(ls);
 
-            plotModel.Axes.Add(GetLinearAxis(theme, AxisPosition.Left, GetMinimumValue(graphDataPoints, sensorClass), GetMaximumValue(graphDataPoints, sensorClass), GetMajorStep(graphDataPoints, sensorClass)));
-            plotModel.Axes.Add(GetLinearAxis(theme, AxisPosition.Right, GetMinimumValue(graphDataPoints, sensorClass), GetMaximumValue(graphDataPoints, sensorClass), GetMajorStep(graphDataPoints, sensorClass)));
+            // If values are all same, use custom min/max values to show graph
+            var minValue = GetMinimumValue(graphDataPoints, sensorClass);
+            var maxValue = GetMaximumValue(graphDataPoints, sensorClass);
+            if (minValue == maxValue)
+            {
+                minValue = minValue - 5;
+                maxValue = maxValue + 5;
+            }
+
+            plotModel.Axes.Add(GetLinearAxis(theme, AxisPosition.Left, minValue, maxValue, GetMajorStep(minValue, maxValue, sensorClass)));
+            plotModel.Axes.Add(GetLinearAxis(theme, AxisPosition.Right, minValue, maxValue, GetMajorStep(minValue, maxValue, sensorClass)));
             plotModel.Axes.Add(GetDateTimeAxis(theme));
 
             switch (theme)
@@ -55,9 +64,9 @@ namespace Vahti.Mobile.Forms.Models
             return plotModel;
         }
 
-        private static double GetMajorStep(List<GraphData> graphData, SensorClass sensorClass)
+        private static double GetMajorStep(double minValue, double maxValue, SensorClass sensorClass)
         {
-            var maxRange = graphData.Max(t => t.Y) - graphData.Min(t => t.Y);
+            var maxRange = maxValue - minValue;
             var majorStep = maxRange / 4;
 
             switch (sensorClass)

--- a/src/Vahti.Web/Vahti.Web.ReactApp/src/components/Graph/Graph.js
+++ b/src/Vahti.Web/Vahti.Web.ReactApp/src/components/Graph/Graph.js
@@ -114,7 +114,15 @@ const Graph = (props) => {
                 return ".1f";
         }
     }
-  
+    
+    // If values are all same, use custom min/max values to show graph
+    let yMin = getMin(props.className, series.min());
+    let yMax = getMax(props.className, series.max());
+    if (yMin === yMax){
+        yMin = yMin - 5;
+        yMax = yMax + 5;
+    }
+
     return (   
         <Resizable className="Graph">
             <ChartContainer 
@@ -131,8 +139,8 @@ const Graph = (props) => {
                         showGrid 
                         tickCount={11} 
                         style={yAxisStyle} 
-                        min={getMin(props.className, series.min())} 
-                        max={getMax(props.className, series.max())} 
+                        min={yMin} 
+                        max={yMax} 
                         format={getFormat(props.className)}
                         width="40"                         
                         />
@@ -145,8 +153,8 @@ const Graph = (props) => {
                         showGrid 
                         tickCount={11} 
                         style={yAxisStyle} 
-                        min={getMin(props.className, series.min())} 
-                        max={getMax(props.className, series.max())} 
+                        min={yMin} 
+                        max={yMax} 
                         format={getFormat(props.className)}
                         width="40"                         
                         />


### PR DESCRIPTION
If all history data values are same, then set y-axis min/max values manually to -5/+5 to get graph shown properly. `OxyPlot` throws exception is y-axis step is zero, which is result if values have no variance. Step is calculated based on min/max values.

React app has same issue, but it does not throw exception though, but it's fixed in same way.

Fixes #17 