### PR TITLE
Show history for calculated measurements

### DIFF
--- a/src/Vahti.DataBroker.Test/DataBroker/DataBrokerTests.cs
+++ b/src/Vahti.DataBroker.Test/DataBroker/DataBrokerTests.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Vahti.DataBroker.AlertHandler;
+using Vahti.DataBroker.Configuration;
+using Vahti.DataBroker.DataProvider;
+using Vahti.Shared;
+using Vahti.Shared.Data;
+using Vahti.Shared.DataProvider;
+
+namespace Vahti.DataBroker.Test.DataBroker
+{
+    /// <Summary>
+    /// Unit tests for <see cref="Vahti.DataBroker.DataBroker.DataBroker>"/>
+    /// </Summary>
+    [TestClass]
+    public class DataBrokerTests
+    {
+        private Mock<ILogger<Vahti.DataBroker.DataBroker.DataBroker>> _loggerMock;
+        private Mock<IOptions<DataBrokerConfiguration>> _configMock;
+        private Mock<IDataProvider> _dataProvider;
+        private Mock<IHistoryDataProvider> _historyDataProvider;
+        private Mock<IAlertHandler> _alertHandler;
+
+        [TestInitialize]
+        public void InitializeTest()
+        {
+            _loggerMock = new Mock<ILogger<Vahti.DataBroker.DataBroker.DataBroker>>();
+            _configMock = new Mock<IOptions<DataBrokerConfiguration>>();
+            _dataProvider = new Mock<IDataProvider>();
+            _historyDataProvider = new Mock<IHistoryDataProvider>();
+            _alertHandler = new Mock<IAlertHandler>();
+        }
+
+        [TestMethod]
+        public async Task PublishHistoryData_HistoryDataAdded_True()
+        {
+            bool sensorHistoryDataStored = false;
+            bool calcMeasurementHistoryDataStored = false;
+
+            const string sensorId = "mySensorId";
+            const string calcSensorId = "myCalcId";            
+            const string sensorDeviceId = "mySensorDeviceId";            
+            _configMock.Setup(config => config.Value).Returns(
+                new DataBrokerConfiguration()
+                {
+                    CloudPublishConfiguration = new CloudPublishConfiguration()
+                    {
+                        Enabled = true,
+                        HistoryLengthDays = 1                        
+                    }
+                });
+            _dataProvider.Setup(dp => dp.StoreNewItemAsync<HistoryData>(It.IsAny<HistoryData>()))
+                .Callback<HistoryData>((historyData) =>
+                {
+                    calcMeasurementHistoryDataStored = historyData.DataList.Count(item => item.SensorDeviceId.Equals(sensorDeviceId) &&
+                        item.SensorId.Equals(calcSensorId)) == 1;                    
+                    sensorHistoryDataStored = historyData.DataList.Count(item => item.SensorDeviceId.Equals(sensorDeviceId) &&
+                        item.SensorId.Equals(sensorId)) == 1;
+                });
+
+            _historyDataProvider.Setup(hdp => hdp.GetHistory(sensorDeviceId, It.IsAny<string>(), 
+                _configMock.Object.Value.CloudPublishConfiguration.HistoryLengthDays))
+                .ReturnsAsync(new List<MeasurementData>());
+            var dataBroker = new Vahti.DataBroker.DataBroker.DataBroker(_loggerMock.Object,
+                _configMock.Object, _dataProvider.Object, _historyDataProvider.Object, 
+                _alertHandler.Object);
+
+            var sensorDeviceType = @"{ ""id"": ""deviceTypeId"", ""name"": ""deviceName"", ""manufacturer"": " +
+                @"""deviceManufacturer"", ""sensors"": [{ ""id"": """ + sensorId + @""", ""name"": " +
+                @"""mySensorName"", ""class"": ""mySensorClass"", ""unit"": ""myUnit""}]}";
+            var sensorDevice = @"{""id"": """ + sensorDeviceId + @""", ""address"": ""myAddress"", " +
+                @"""name"": ""mySensorName"", ""sensorDeviceTypeId"": ""deviceTypeId"", " +
+                @"""location"": ""myLocation"", ""calculatedMeasurements"": [{ ""id"": " +
+                @"""" + calcSensorId + @""", ""name"": ""myCalcName"", ""class"": ""myCalcClass"", " +
+                @"""unit"": ""myCalcUnit"", ""type"": 1, ""sensorId"": ""mySensorId"", " +
+                @"""operator"": 0, ""value"": ""1"" }]}";
+            dataBroker.MqttMessageReceived(Constant.TopicSensorDeviceType, sensorDeviceType);
+            dataBroker.MqttMessageReceived(Constant.TopicSensorDevice, sensorDevice);
+
+            await dataBroker.PublishHistoryData();
+                        
+            Assert.IsTrue(calcMeasurementHistoryDataStored, "History data for calculated measurement was not stored");
+            Assert.IsTrue(sensorHistoryDataStored, "History data for sensor was not stored");
+        }
+    }
+}

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms.Test/Services/HistoryDataServiceTests.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms.Test/Services/HistoryDataServiceTests.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Vahti.Mobile.Forms.Services;
+using Vahti.Shared.Data;
+using Vahti.Shared.DataProvider;
+using Vahti.Shared.TypeData;
+
+namespace Vahti.Mobile.Forms.Test.Services
+{
+    /// <summary>
+    ///  Unit tests for <see cref="HistoryDataService"/>
+    /// </summary>
+    [TestClass]
+    public class HistoryDataServiceTests
+    {        
+        [TestMethod]
+        public async Task GetAllDataAsync_CustomMeasurementHandledCorrectly()
+        {
+            var customUnit = "myCustomUnit";
+            var customSensorId = "myCustomSensorId";
+
+            var sensorDeviceTypeList = new List<SensorDeviceType>()
+            {
+                new SensorDeviceType()
+                {
+                    Id = "mySensorDeviceTypeId",
+                    Name = "mySensorDeviceTypeName",
+                    Sensors = new List<Sensor>()
+                    {
+                        new Sensor()
+                        {
+                            Id = "mySensorId"
+                        }
+                    }
+                }
+            };
+
+            var sensorDeviceList = new List<SensorDevice>()
+            {
+                new SensorDevice()
+                {
+                    Id = "mySensorDeviceId",
+                    SensorDeviceTypeId = "mySensorDeviceTypeId",
+                    CalculatedMeasurements = new List<CustomMeasurementRule>()
+                    {
+                        new CustomMeasurementRule()
+                        {
+                            Id = customSensorId,
+                            Unit = customUnit
+                        }
+                    }
+                }
+            };
+
+            var historyDataList = new List<HistoryData>()
+            {
+                new HistoryData()
+                {
+                    DataList = new List<MeasurementHistoryData>()
+                    {
+                        new MeasurementHistoryData()
+                        {
+                            SensorDeviceId = "mySensorDeviceId",
+                            SensorId = customSensorId,
+                            Values = new List<HistoryValueData>()
+                            {
+                                new HistoryValueData()
+                                {
+                                    Timestamp = DateTime.Now,
+                                    Value = "1"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var dataProvider = new Mock<IDataProvider>();
+            dataProvider.Setup(dp => dp.LoadAllItemsAsync<SensorDeviceType>())
+                .ReturnsAsync(sensorDeviceTypeList);
+            dataProvider.Setup(dp => dp.LoadAllItemsAsync<SensorDevice>())
+                .ReturnsAsync(sensorDeviceList);
+            dataProvider.Setup(dp => dp.LoadAllItemsAsync<HistoryData>())
+                .ReturnsAsync(historyDataList);
+
+            var historyDataService = new HistoryDataService(dataProvider.Object);
+
+            var historyItems = await historyDataService.GetAllDataAsync(true);
+
+            Assert.AreEqual(1, historyItems.Count, "There should be one history item");
+            Assert.AreEqual(customSensorId, historyItems.First().SensorId, "Incorrect SensorId");
+            Assert.AreEqual(customUnit, historyItems.First().Unit, "Incorrect Unit");
+        }
+    }
+}

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms.Test/Vahti.Mobile.Forms.Test.csproj
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms.Test/Vahti.Mobile.Forms.Test.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Vahti.Mobile.Forms\Vahti.Mobile.Forms.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Services/HistoryDataService.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Services/HistoryDataService.cs
@@ -43,7 +43,13 @@ namespace Vahti.Mobile.Forms.Services
                 foreach (var item in _historyData.DataList)
                 {
                     var sensorDeviceType = _sensorDeviceTypes[_sensorDevices[item.SensorDeviceId].SensorDeviceTypeId];
-                    var unit = sensorDeviceType.Sensors.FirstOrDefault(s => s.Id.Equals(item.SensorId)).Unit;
+                    var unit = sensorDeviceType.Sensors.FirstOrDefault(s => s.Id.Equals(item.SensorId))?.Unit;
+                    if (unit == null)
+                    {
+                        unit = _sensorDevices[item.SensorDeviceId].CalculatedMeasurements?
+                            .FirstOrDefault(cm => cm.Id.Equals(item.SensorId))?.Unit;
+                    }
+
                     var uiItem = new MeasurementHistory() { SensorDeviceId = item.SensorDeviceId, SensorId = item.SensorId, Values = item.Values, Unit = unit };
 
                     historyItems.Add(uiItem);                    

--- a/src/Vahti.sln
+++ b/src/Vahti.sln
@@ -30,6 +30,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vahti.Server", "Vahti.Server\Vahti.Server.csproj", "{2CDD797D-4293-41EB-ABB9-AFD0E7F4FB81}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vahti.Mobile.Forms.Test", "Vahti.Mobile\Vahti.Mobile.Forms.Test\Vahti.Mobile.Forms.Test.csproj", "{515274EF-0414-47FA-9BA9-90C3C62CB57F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -230,6 +232,24 @@ Global
 		{2CDD797D-4293-41EB-ABB9-AFD0E7F4FB81}.Release|iPhone.Build.0 = Release|Any CPU
 		{2CDD797D-4293-41EB-ABB9-AFD0E7F4FB81}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{2CDD797D-4293-41EB-ABB9-AFD0E7F4FB81}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.DebugMock|Any CPU.ActiveCfg = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.DebugMock|Any CPU.Build.0 = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.DebugMock|iPhone.ActiveCfg = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.DebugMock|iPhone.Build.0 = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.DebugMock|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.DebugMock|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Release|iPhone.Build.0 = Release|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -238,6 +258,7 @@ Global
 		{91EC24AD-ED2D-40DD-AEF5-8069480020DF} = {E41C4451-BD23-43D9-882F-ED09B258E09A}
 		{45E2C9BF-558D-4F2D-8E9F-19DB7C5CC0E5} = {E41C4451-BD23-43D9-882F-ED09B258E09A}
 		{055448A6-DFB1-4303-8B08-ECCE0E4F6F62} = {E41C4451-BD23-43D9-882F-ED09B258E09A}
+		{515274EF-0414-47FA-9BA9-90C3C62CB57F} = {E41C4451-BD23-43D9-882F-ED09B258E09A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {97DE16B6-0BBC-40F6-A947-1F44B83A07C7}


### PR DESCRIPTION
`DataBroker` now publishes the history data also for calculated measurements in addition to regular sensor measurements. `HistoryDataService` is fixed so that it's able to handle history data of calculated measurements now.

This affects only users who have specified a calculated measurement for a `SensorDevice`.

Fixed #16 