### PR TITLE
Show 24h min/max values on mobile app graph page

### DIFF
--- a/src/Vahti.Mobile/Vahti.Mobile.Android/DataWidget.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Android/DataWidget.cs
@@ -79,19 +79,22 @@ namespace Vahti.Mobile.Droid
                     {
                         widgetView.SetTextViewText(Resource.Id.location1, measurements[0].Item1);
                         widgetView.SetTextViewText(Resource.Id.sensor1, measurements[0].Item2.SensorName);
-                        widgetView.SetTextViewText(Resource.Id.value1, DisplayValueFormatter.GetMeasurementDisplayValue(measurements[0].Item2));
+                        widgetView.SetTextViewText(Resource.Id.value1, DisplayValueFormatter.GetMeasurementDisplayValue(
+                            measurements[0].Item2.SensorClass, measurements[0].Item2.Value, measurements[0].Item2.Unit));
                     }
                     if (measurements.Count >= 2)
                     {
                         widgetView.SetTextViewText(Resource.Id.location2, measurements[1].Item1);
                         widgetView.SetTextViewText(Resource.Id.sensor2, measurements[1].Item2.SensorName);
-                        widgetView.SetTextViewText(Resource.Id.value2, DisplayValueFormatter.GetMeasurementDisplayValue(measurements[1].Item2));
+                        widgetView.SetTextViewText(Resource.Id.value2, DisplayValueFormatter.GetMeasurementDisplayValue(
+                            measurements[1].Item2.SensorClass, measurements[1].Item2.Value, measurements[1].Item2.Unit));
                     }
                     if (measurements.Count >= 3)
                     {
                         widgetView.SetTextViewText(Resource.Id.location3, measurements[2].Item1);
                         widgetView.SetTextViewText(Resource.Id.sensor3, measurements[2].Item2.SensorName);
-                        widgetView.SetTextViewText(Resource.Id.value3, DisplayValueFormatter.GetMeasurementDisplayValue(measurements[2].Item2));
+                        widgetView.SetTextViewText(Resource.Id.value3, DisplayValueFormatter.GetMeasurementDisplayValue(
+                            measurements[2].Item2.SensorClass, measurements[2].Item2.Value, measurements[2].Item2.Unit));
                     }
                     var firstLocation = locationList.FirstOrDefault();
                     widgetView.SetTextViewText(Resource.Id.updated, string.Format("{0}:{1}", firstLocation.Timestamp.Hour, firstLocation.Timestamp.Minute.ToString("00")));

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/App.xaml.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/App.xaml.cs
@@ -57,6 +57,7 @@ namespace Vahti.Mobile.Forms
             containerBuilder.RegisterType<LocationDataService>().As(typeof(IDataService<Models.Location>)).SingleInstance();
             containerBuilder.RegisterType<HistoryDataService>().As(typeof(IDataService<MeasurementHistory>)).SingleInstance();            
             containerBuilder.RegisterType<NavigationService>().As(typeof(INavigationService)).SingleInstance();
+            containerBuilder.RegisterType<OptionService>().As(typeof(IOptionService)).SingleInstance();
 
             // Register view models
             containerBuilder.RegisterType<LocationListViewModel>().As(typeof(LocationListViewModel)).SingleInstance().AutoActivate();            

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Converters/MeasurementValueToDisplayStringConverter.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Converters/MeasurementValueToDisplayStringConverter.cs
@@ -14,7 +14,8 @@ namespace Vahti.Mobile.Forms.Converters
         {
             if (value != null && value is Measurement)
             {
-                return DisplayValueFormatter.GetMeasurementDisplayValue((Measurement)value);
+                var measurement = value as Measurement;
+                return DisplayValueFormatter.GetMeasurementDisplayValue(measurement.SensorClass, measurement.Value, measurement.Unit);
             }
             return null;
         }

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Localization/DisplayValueFormatter.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Localization/DisplayValueFormatter.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using Vahti.Mobile.Forms.Models;
 using Vahti.Shared.Enum;
 
 namespace Vahti.Mobile.Forms.Localization
@@ -9,24 +8,36 @@ namespace Vahti.Mobile.Forms.Localization
     /// </summary>
     public static class DisplayValueFormatter
     {
-        public static string GetMeasurementDisplayValue(Measurement measurement)
+        public static string GetMeasurementDisplayValue(SensorClass sensorClass, string value, string unit)
         {
-            switch (measurement.SensorClass)
+            var valueWithoutUnit = GetMeasurementDisplayValue(sensorClass, value);
+
+            if (!string.IsNullOrEmpty(valueWithoutUnit))
+            {
+                valueWithoutUnit += $" {unit}";
+            }
+
+            return valueWithoutUnit;
+        }
+
+        public static string GetMeasurementDisplayValue(SensorClass sensorClass, string value)
+        {
+            switch (sensorClass)
             {
                 case SensorClass.None:
                     return string.Empty;
                 case SensorClass.Temperature:
-                    return $"{string.Format("{0:0.0}", double.Parse(measurement.Value, CultureInfo.InvariantCulture))} {measurement.Unit}";
+                    return $"{string.Format("{0:0.0}", double.Parse(value, CultureInfo.InvariantCulture))}";
                 case SensorClass.AccelerationX:
                 case SensorClass.AccelerationY:
                 case SensorClass.AccelerationZ:
                 case SensorClass.BatteryVoltage:
-                    return $"{string.Format("{0:0.000}", double.Parse(measurement.Value, CultureInfo.InvariantCulture))} {measurement.Unit}";
+                    return $"{string.Format("{0:0.000}", double.Parse(value, CultureInfo.InvariantCulture))}";
                 case SensorClass.Humidity:
                 case SensorClass.MovementCounter:
                 case SensorClass.Pressure:
                 default:
-                    return $"{string.Format("{0:0}", double.Parse(measurement.Value, CultureInfo.InvariantCulture))} {measurement.Unit}";
+                    return $"{string.Format("{0:0}", double.Parse(value, CultureInfo.InvariantCulture))}";
             }
         }
     }

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Models/GraphModel.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Models/GraphModel.cs
@@ -53,27 +53,24 @@ namespace Vahti.Mobile.Forms.Models
             plotModel.Axes.Add(GetDateTimeAxis(theme));
             
             if (showMinMax)
-            {                
-                try
-                {
-                    var minValue24h = Get24hMinimumValue(graphDataPoints, sensorClass);
-                    var maxValue24h = Get24hMaximumValue(graphDataPoints, sensorClass);
+            {
+                var minValue24h = Get24hMinimumValue(graphDataPoints);
+                var maxValue24h = Get24hMaximumValue(graphDataPoints);
 
+                if (minValue24h != null && maxValue24h != null)
+                {
                     plotModel.Annotations.Add(new CustomTextAnnotation()
                     {
                         X = 6,
                         Y = 6,
                         Text = string.Format(Resources.AppResources.Graph_MinMax,
-                        DisplayValueFormatter.GetMeasurementDisplayValue(sensorClass, minValue24h.ToString(DotNumberFormatInfo)),
-                        DisplayValueFormatter.GetMeasurementDisplayValue(sensorClass, maxValue24h.ToString(DotNumberFormatInfo)), historyData.Unit),
+                            DisplayValueFormatter.GetMeasurementDisplayValue(sensorClass, minValue24h.Value.ToString(DotNumberFormatInfo)),
+                            DisplayValueFormatter.GetMeasurementDisplayValue(sensorClass, maxValue24h.Value.ToString(DotNumberFormatInfo)), 
+                            historyData.Unit),
                         FontSize = 12,
                         TextColor = OxyColors.White
                     });
-                }
-                catch (InvalidOperationException)
-                {
-                    // No values from last 24h, do not add min/max annotation
-                }
+                }                
             }
             
             switch (theme)
@@ -141,20 +138,26 @@ namespace Vahti.Mobile.Forms.Models
             }
         }
 
-        private static double Get24hMinimumValue(List<GraphData> graphData, SensorClass category)
-        {
-            var now = DateTime.Now;
-            var dataMinValue = graphData.Where(t => (now - t.X).Days == 0).Min(t => t.Y);
+        private static double? Get24hMinimumValue(List<GraphData> graphData)
+        {         
+            var values24h = graphData.Where(t => (DateTime.Now - t.X).Days == 0).ToList();
+            if (values24h.Count == 0)
+            {
+                return null;
+            }
 
-            return dataMinValue;
+            return values24h.Min(t => t.Y);
         }
 
-        private static double Get24hMaximumValue(List<GraphData> graphData, SensorClass category)
-        {
-            var now = DateTime.Now;           
-            var dataMaxValue = graphData.Where(t => (now - t.X).Days == 0).Max(t => t.Y);
+        private static double? Get24hMaximumValue(List<GraphData> graphData)
+        {            
+            var values24h = graphData.Where(t => (DateTime.Now - t.X).Days == 0).ToList();
+            if (values24h.Count == 0)
+            {
+                return null;
+            }
 
-            return dataMaxValue;
+            return values24h.Max(t => t.Y);
         }
 
         private static double GetMaximumValue(List<GraphData> graphData, SensorClass category)

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/MultilingualResources/Vahti.Mobile.Forms.fi.xlf
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/MultilingualResources/Vahti.Mobile.Forms.fi.xlf
@@ -36,8 +36,8 @@
           <target state="translated">Historia</target>
         </trans-unit>
         <trans-unit id="Options_ColorThemeLabel" translate="yes" xml:space="preserve">
-          <source>Color theme:</source>
-          <target state="translated">Väriteema:</target>
+          <source>Color theme</source>
+          <target state="translated">Väriteema</target>
         </trans-unit>
         <trans-unit id="Options_Title" translate="yes" xml:space="preserve">
           <source>Options</source>
@@ -68,12 +68,12 @@
           <target state="translated">Ongelma haettaessa dataa tietokannasta. Tarkista että tietokannan osoite on määritelty oikein App.config-tiedostossa: {0}. Jos haluat sen sijaan käyttää testidataa, valitse "DebugMock" käännöskonfiguraatio</target>
         </trans-unit>
         <trans-unit id="Options_CloudDatabaseSecretLabel" translate="yes" xml:space="preserve">
-          <source>Cloud database secret:</source>
-          <target state="translated">Pilvitietokannan salasana:</target>
+          <source>Secret</source>
+          <target state="translated">Salasana</target>
         </trans-unit>
         <trans-unit id="Options_CloudDatabaseUrlLabel" translate="yes" xml:space="preserve">
-          <source>Cloud database URL:</source>
-          <target state="translated">Pilvitietokannan osoite:</target>
+          <source>URL</source>
+          <target state="translated">Osoite</target>
         </trans-unit>
         <trans-unit id="Options_CloudDatabaseUrlMissingLabel" translate="yes" xml:space="preserve">
           <source>Cloud database URL has to be specified</source>
@@ -106,6 +106,22 @@
         <trans-unit id="Options_Sorting_Title" translate="yes" xml:space="preserve">
           <source>Sorting</source>
           <target state="translated">Järjestys</target>
+        </trans-unit>
+        <trans-unit id="Options_ShowMinMaxValuesLabel" translate="yes" xml:space="preserve">
+          <source>Show min/max (24h)</source>
+          <target state="translated">Näytä min/max (24h)</target>
+        </trans-unit>
+        <trans-unit id="Options_GraphPageHeader" translate="yes" xml:space="preserve">
+          <source>History view</source>
+          <target state="translated">Historianäkymä</target>
+        </trans-unit>
+        <trans-unit id="Options_DatabaseOptionsHeader" translate="yes" xml:space="preserve">
+          <source>Cloud database</source>
+          <target state="translated">Pilvitietokanta</target>
+        </trans-unit>
+        <trans-unit id="Graph_MinMax" translate="yes" xml:space="preserve">
+          <source>24h: {0} ... {1} {2}</source>
+          <target state="translated">24h: {0} ... {1} {2}</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.Designer.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.Designer.cs
@@ -142,6 +142,15 @@ namespace Vahti.Mobile.Forms.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 24h: {0} ... {1} {2}.
+        /// </summary>
+        internal static string Graph_MinMax {
+            get {
+                return ResourceManager.GetString("Graph_MinMax", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to History.
         /// </summary>
         internal static string Graph_Title {
@@ -178,7 +187,7 @@ namespace Vahti.Mobile.Forms.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cloud database secret:.
+        ///   Looks up a localized string similar to Secret.
         /// </summary>
         internal static string Options_CloudDatabaseSecretLabel {
             get {
@@ -187,7 +196,7 @@ namespace Vahti.Mobile.Forms.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cloud database URL:.
+        ///   Looks up a localized string similar to URL.
         /// </summary>
         internal static string Options_CloudDatabaseUrlLabel {
             get {
@@ -205,11 +214,20 @@ namespace Vahti.Mobile.Forms.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Color theme:.
+        ///   Looks up a localized string similar to Color theme.
         /// </summary>
         internal static string Options_ColorThemeLabel {
             get {
                 return ResourceManager.GetString("Options_ColorThemeLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cloud database.
+        /// </summary>
+        internal static string Options_DatabaseOptionsHeader {
+            get {
+                return ResourceManager.GetString("Options_DatabaseOptionsHeader", resourceCulture);
             }
         }
         
@@ -219,6 +237,24 @@ namespace Vahti.Mobile.Forms.Resources {
         internal static string Options_General_Title {
             get {
                 return ResourceManager.GetString("Options_General_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to History view.
+        /// </summary>
+        internal static string Options_GraphPageHeader {
+            get {
+                return ResourceManager.GetString("Options_GraphPageHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show min/max (24h).
+        /// </summary>
+        internal static string Options_ShowMinMaxValuesLabel {
+            get {
+                return ResourceManager.GetString("Options_ShowMinMaxValuesLabel", resourceCulture);
             }
         }
         

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.fi.resx
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.fi.resx
@@ -32,7 +32,7 @@
     <value>Historia</value>
   </data>
   <data name="Options_ColorThemeLabel" xml:space="preserve">
-    <value>Väriteema:</value>
+    <value>Väriteema</value>
   </data>
   <data name="Options_Title" xml:space="preserve">
     <value>Asetukset</value>
@@ -56,10 +56,10 @@
     <value>Ongelma haettaessa dataa tietokannasta. Tarkista että tietokannan osoite on määritelty oikein App.config-tiedostossa: {0}. Jos haluat sen sijaan käyttää testidataa, valitse "DebugMock" käännöskonfiguraatio</value>
   </data>
   <data name="Options_CloudDatabaseSecretLabel" xml:space="preserve">
-    <value>Pilvitietokannan salasana:</value>
+    <value>Salasana</value>
   </data>
   <data name="Options_CloudDatabaseUrlLabel" xml:space="preserve">
-    <value>Pilvitietokannan osoite:</value>
+    <value>Osoite</value>
   </data>
   <data name="Options_CloudDatabaseUrlMissingLabel" xml:space="preserve">
     <value>Pilvitietokannan osoite pitää määrittää tietojen näyttämiseksi</value>
@@ -84,5 +84,17 @@
   </data>
   <data name="Options_Sorting_Title" xml:space="preserve">
     <value>Järjestys</value>
+  </data>
+  <data name="Options_ShowMinMaxValuesLabel" xml:space="preserve">
+    <value>Näytä min/max (24h)</value>
+  </data>
+  <data name="Options_GraphPageHeader" xml:space="preserve">
+    <value>Historianäkymä</value>
+  </data>
+  <data name="Options_DatabaseOptionsHeader" xml:space="preserve">
+    <value>Pilvitietokanta</value>
+  </data>
+  <data name="Graph_MinMax" xml:space="preserve">
+    <value>24h: {0} ... {1} {2}</value>
   </data>
 </root>

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.resx
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.resx
@@ -144,6 +144,9 @@
   <data name="Details_Title" xml:space="preserve">
     <value>Details</value>
   </data>
+  <data name="Graph_MinMax" xml:space="preserve">
+    <value>24h: {0} ... {1} {2}</value>
+  </data>
   <data name="Graph_Title" xml:space="preserve">
     <value>History</value>
   </data>
@@ -157,19 +160,28 @@
     <value>Refresh</value>
   </data>
   <data name="Options_CloudDatabaseSecretLabel" xml:space="preserve">
-    <value>Cloud database secret:</value>
+    <value>Secret</value>
   </data>
   <data name="Options_CloudDatabaseUrlLabel" xml:space="preserve">
-    <value>Cloud database URL:</value>
+    <value>URL</value>
   </data>
   <data name="Options_CloudDatabaseUrlMissingLabel" xml:space="preserve">
     <value>Cloud database URL has to be specified</value>
   </data>
   <data name="Options_ColorThemeLabel" xml:space="preserve">
-    <value>Color theme:</value>
+    <value>Color theme</value>
+  </data>
+  <data name="Options_DatabaseOptionsHeader" xml:space="preserve">
+    <value>Cloud database</value>
   </data>
   <data name="Options_General_Title" xml:space="preserve">
     <value>General</value>
+  </data>
+  <data name="Options_GraphPageHeader" xml:space="preserve">
+    <value>History view</value>
+  </data>
+  <data name="Options_ShowMinMaxValuesLabel" xml:space="preserve">
+    <value>Show min/max (24h)</value>
   </data>
   <data name="Options_Sorting_Description" xml:space="preserve">
     <value>Sort locations using arrows:</value>

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Services/IOptionService.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Services/IOptionService.cs
@@ -1,0 +1,7 @@
+﻿namespace Vahti.Mobile.Forms.Services
+{
+    public interface IOptionService
+    {
+        bool ShowMinMaxValues { get; set; }
+    }
+}

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Services/OptionService.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Services/OptionService.cs
@@ -1,0 +1,24 @@
+﻿using Xamarin.Essentials;
+
+namespace Vahti.Mobile.Forms.Services
+{
+    /// <summary>
+    /// Provides application option information
+    /// </summary>
+    public class OptionService : IOptionService
+    {
+        private const string ShowMinMaxValuesPreferenceName = "ShowMinMaxValues";
+
+        public bool ShowMinMaxValues
+        {
+            get
+            {
+                return Preferences.Get(ShowMinMaxValuesPreferenceName, false);
+            }
+            set
+            {
+                Preferences.Set(ShowMinMaxValuesPreferenceName, value);
+            }
+        }
+    }
+}

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/ViewModels/LocationGraphViewModel.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/ViewModels/LocationGraphViewModel.cs
@@ -6,15 +6,10 @@ using System.Threading.Tasks;
 using OxyPlot;
 using Vahti.Mobile.Forms.Exceptions;
 using Vahti.Mobile.Forms.Models;
-using Xamarin.Essentials;
 using Xamarin.Forms;
 using Vahti.Mobile.Forms.EventArguments;
 using Vahti.Mobile.Forms.Services;
 using System.Collections.ObjectModel;
-using MvvmHelpers.Interfaces;
-using System.Windows.Input;
-using MvvmHelpers.Commands;
-using Command = MvvmHelpers.Commands.Command;
 
 namespace Vahti.Mobile.Forms.ViewModels
 {
@@ -24,12 +19,13 @@ namespace Vahti.Mobile.Forms.ViewModels
     public class LocationGraphViewModel : BaseViewModel
     {
         private readonly IDataService<MeasurementHistory> _historyDataService;
+        private readonly IOptionService _optionService;
         private ObservableCollection<IPlotModel> _plotModels = new ObservableCollection<IPlotModel>();
         private Models.Location _selectedLocation;
         private bool _showGraphs = false;
         
-        public IAsyncCommand<bool> RefreshGraphCommand { get; }
-        public ICommand ShowDetailsCommand { get; set; }
+        public Command<bool> RefreshGraphCommand { get; }
+        public Command ShowDetailsCommand { get; set; }
 
         public ObservableCollection<IPlotModel> PlotModels
         {
@@ -67,11 +63,14 @@ namespace Vahti.Mobile.Forms.ViewModels
             }
         }    
 
-        public LocationGraphViewModel(IDataService<MeasurementHistory> dataStore, INavigationService navigationService) : base(navigationService)
+        public LocationGraphViewModel(IDataService<MeasurementHistory> dataStore, INavigationService navigationService,
+            IOptionService optionService) : base(navigationService)
         {
             _historyDataService = dataStore;
+            _optionService = optionService;
+
             NavigationService.NavigatedTo += NavigationService_NavigatedTo;
-            RefreshGraphCommand = new AsyncCommand<bool>(async (forceRefresh) => await RefreshDataAsync(forceRefresh));
+            RefreshGraphCommand = new Command<bool>(async (forceRefresh) => await RefreshDataAsync(forceRefresh));
             ShowDetailsCommand = new Command(() =>
             {   
                 NavigationService.NavigateTo(Constants.PageType.Details, SelectedLocation);                
@@ -118,7 +117,7 @@ namespace Vahti.Mobile.Forms.ViewModels
                         continue;
                     }
 
-                    PlotModels.Add(GraphModel.GetPlotModel(historyItem, measurement.SensorClass, measurement.SensorName));
+                    PlotModels.Add(GraphModel.GetPlotModel(historyItem, measurement.SensorClass, measurement.SensorName, _optionService.ShowMinMaxValues));
                 }
             }
             catch (Exception ex)

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/ViewModels/LocationGraphViewModel.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/ViewModels/LocationGraphViewModel.cs
@@ -10,6 +10,10 @@ using Xamarin.Forms;
 using Vahti.Mobile.Forms.EventArguments;
 using Vahti.Mobile.Forms.Services;
 using System.Collections.ObjectModel;
+using MvvmHelpers.Interfaces;
+using System.Windows.Input;
+using MvvmHelpers.Commands;
+using Command = MvvmHelpers.Commands.Command;
 
 namespace Vahti.Mobile.Forms.ViewModels
 {
@@ -24,8 +28,8 @@ namespace Vahti.Mobile.Forms.ViewModels
         private Models.Location _selectedLocation;
         private bool _showGraphs = false;
         
-        public Command<bool> RefreshGraphCommand { get; }
-        public Command ShowDetailsCommand { get; set; }
+        public IAsyncCommand<bool> RefreshGraphCommand { get; }
+        public ICommand ShowDetailsCommand { get; set; }
 
         public ObservableCollection<IPlotModel> PlotModels
         {
@@ -70,7 +74,7 @@ namespace Vahti.Mobile.Forms.ViewModels
             _optionService = optionService;
 
             NavigationService.NavigatedTo += NavigationService_NavigatedTo;
-            RefreshGraphCommand = new Command<bool>(async (forceRefresh) => await RefreshDataAsync(forceRefresh));
+            RefreshGraphCommand = new AsyncCommand<bool>(async (forceRefresh) => await RefreshDataAsync(forceRefresh));
             ShowDetailsCommand = new Command(() =>
             {   
                 NavigationService.NavigateTo(Constants.PageType.Details, SelectedLocation);                

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/ViewModels/OptionsGeneralViewModel.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/ViewModels/OptionsGeneralViewModel.cs
@@ -9,9 +9,11 @@ namespace Vahti.Mobile.Forms.ViewModels
     /// View model for page displaying application options
     /// </summary>
     public class OptionsGeneralViewModel : BaseViewModel
-    {
+    {        
         private int _colorThemesSelectedIndex;
+        private bool _showMinMaxValues;
         private IDatabaseManagementService _dbManagementService;
+        private IOptionService _optionService;
         private string _databaseSecret;
         private string _databaseUrl;
         private string _selectedColorTheme = null;              
@@ -62,7 +64,23 @@ namespace Vahti.Mobile.Forms.ViewModels
             }
         }
 
-        
+        public bool ShowMinMaxValues
+        {
+            get
+            {
+                return _showMinMaxValues;
+            }
+            set
+            {
+                if (_showMinMaxValues != value)
+                {
+                    _showMinMaxValues = value;
+                    _optionService.ShowMinMaxValues = value;
+                    SetProperty(ref _showMinMaxValues, value, nameof(ShowMinMaxValues));
+                }
+            }
+        }
+
         public string SelectedColorTheme
         {
             get
@@ -79,9 +97,12 @@ namespace Vahti.Mobile.Forms.ViewModels
             }
         }
         
-        public OptionsGeneralViewModel(INavigationService navigationService, IDatabaseManagementService dbManagementService) : base(navigationService)
+        public OptionsGeneralViewModel(INavigationService navigationService, IDatabaseManagementService dbManagementService,
+            IOptionService optionService) : base(navigationService)
         {
             _dbManagementService = dbManagementService;
+            _optionService = optionService;
+
             ColorThemes.Add(Resources.AppResources.ColorTheme_Gray);
             ColorThemes.Add(Resources.AppResources.ColorTheme_Light);
 
@@ -95,7 +116,7 @@ namespace Vahti.Mobile.Forms.ViewModels
 
             // For backwards compatibility (green theme does not exist anymore, light is now '1')
             ColorThemesSelectedIndex = (colorThemeIndex == 2) ? 1 : colorThemeIndex;
-
+            ShowMinMaxValues = optionService.ShowMinMaxValues;
             Title = Resources.AppResources.Options_Title;
 
             this.PropertyChanged += OptionsViewModel_PropertyChanged;

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Views/OptionsGeneralPage.xaml
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Views/OptionsGeneralPage.xaml
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"             
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"                
              xmlns:effects="clr-namespace:Vahti.Mobile.Forms.Effects"
              xmlns:i18n="clr-namespace:Vahti.Mobile.Forms.Localization"             
              xmlns:converter="clr-namespace:Vahti.Mobile.Forms.Converters"   
              x:Class="Vahti.Mobile.Forms.Views.OptionsGeneralPage"
+             x:Name="optionsGeneralPage"
              BackgroundColor="{DynamicResource ThemeBackground}"
              Title="{Binding Title}"
              >
@@ -14,10 +15,14 @@
             <Setter Property="FontSize" Value="Small"/>
             <Setter Property="TextColor" Value="{DynamicResource ThemeOnSurface}"/>
         </Style>
+        <Style x:Key="OptionsHeaderStyle" TargetType="Label" >
+            <Setter Property="FontSize" Value="Medium"/>
+            <Setter Property="TextColor" Value="{DynamicResource ThemeOnSurface}"/>
+        </Style>
     </ContentPage.Resources>
     <StackLayout BackgroundColor="{DynamicResource ThemeSurface}" Margin="4" Spacing="20" Padding="24">
         <StackLayout Orientation="Vertical">
-            <Label Text="{i18n:Translate Options_ColorThemeLabel}" Style="{DynamicResource OptionsLabelStyle}" />
+            <Label Text="{i18n:Translate Options_ColorThemeLabel}" Style="{DynamicResource OptionsHeaderStyle}" />
             <Picker x:Name="colorThemePicker" 
                     ItemsSource="{Binding ColorThemes}" 
                     SelectedIndex="{Binding ColorThemesSelectedIndex}" 
@@ -28,7 +33,22 @@
                 </Picker.Effects>
             </Picker>
         </StackLayout>
-        <StackLayout Orientation="Vertical" IsVisible="{Binding IsDatabaseConfigurationInAppNeeded}">        
+        <StackLayout Orientation="Vertical">
+            <Label Text="{i18n:Translate Options_GraphPageHeader}" Style="{DynamicResource OptionsHeaderStyle}" />
+            <Grid RowSpacing="0" Padding="0,8,4,8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="auto"/>
+                </Grid.ColumnDefinitions>
+                <Label Text="{i18n:Translate Options_ShowMinMaxValuesLabel}" Style="{DynamicResource OptionsLabelStyle}" Grid.Column="0"/>
+                <Switch IsToggled="{Binding ShowMinMaxValues}" HorizontalOptions="End" ThumbColor="{DynamicResource ThemeSwitchThumbColor}" OnColor="{DynamicResource ThemeSecondary}" Grid.Column="1"/>
+            </Grid>            
+        </StackLayout>
+        <StackLayout Orientation="Vertical" IsVisible="{Binding IsDatabaseConfigurationInAppNeeded}">
+            <Label Text="{i18n:Translate Options_DatabaseOptionsHeader}" Style="{DynamicResource OptionsHeaderStyle}"/>
             <Label Text="{i18n:Translate Options_CloudDatabaseUrlLabel}" Style="{DynamicResource OptionsLabelStyle}"/>
             <StackLayout Orientation="Vertical" Spacing="0">
                 <Entry Text="{Binding DatabaseUrl}" 

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Views/OptionsSummaryPage.xaml
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Views/OptionsSummaryPage.xaml
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Vahti.Mobile.Forms.Views.OptionsSummaryPage"
-             xmlns:custom="clr-namespace:Vahti.Mobile.Forms.Views.Custom"
+             x:Class="Vahti.Mobile.Forms.Views.OptionsSummaryPage"             
              xmlns:i18n="clr-namespace:Vahti.Mobile.Forms.Localization"
              xmlns:behaviors="clr-namespace:Vahti.Mobile.Forms.Behaviors"
              xmlns:converters="clr-namespace:Vahti.Mobile.Forms.Converters"


### PR DESCRIPTION
Adds support for showing min/max values from last 24 hours in graphs. It's done by adding an `Annotation` in the `PlotModel`.
![image](https://user-images.githubusercontent.com/53601355/139570571-313c5613-b54f-4c35-bde0-592acfbc9d6f.png)

The feature can be turned on from general options page. `OptionsGeneralPage`. Adds also header texts for option items to improve readability.
![image](https://user-images.githubusercontent.com/53601355/139570745-4ca1a16a-4d5a-46bb-8a60-4e1cdb20036b.png)

