### PR TITLE
Show notification in mobile app if data on server has not been updated for a while

### DIFF
--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/MultilingualResources/Vahti.Mobile.Forms.fi.xlf
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/MultilingualResources/Vahti.Mobile.Forms.fi.xlf
@@ -56,8 +56,8 @@
           <target state="translated">Ei tietoa</target>
         </trans-unit>
         <trans-unit id="Locations_LastUpdatedText" translate="yes" xml:space="preserve">
-          <source>Data was last updated on {0}</source>
-          <target state="translated">Tiedot päivitetty viimeksi {0}</target>
+          <source>Data ({0}) was last updated on {1} or earlier</source>
+          <target state="translated">Tiedot ({0}) päivitetty viimeksi {1} tai aikaisemmin</target>
         </trans-unit>
         <trans-unit id="Locations_UpdateButtonText" translate="yes" xml:space="preserve">
           <source>Refresh</source>

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.Designer.cs
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.Designer.cs
@@ -169,7 +169,7 @@ namespace Vahti.Mobile.Forms.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Data was last updated on {0}.
+        ///   Looks up a localized string similar to Data ({0}) was last updated on {1} or earlier.
         /// </summary>
         internal static string Locations_LastUpdatedText {
             get {

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.fi.resx
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.fi.resx
@@ -47,7 +47,7 @@
     <value>Ei tietoa</value>
   </data>
   <data name="Locations_LastUpdatedText" xml:space="preserve">
-    <value>Tiedot päivitetty viimeksi {0}</value>
+    <value>Tiedot ({0}) päivitetty viimeksi {1} tai aikaisemmin</value>
   </data>
   <data name="Locations_UpdateButtonText" xml:space="preserve">
     <value>Päivitä</value>

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.resx
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Resources/AppResources.resx
@@ -154,7 +154,7 @@
     <value>There was a problem when accessing the database. Please check that URL defined in App.config is valid: {0}. To use fake data instead, select "DebugMock" build configuration</value>
   </data>
   <data name="Locations_LastUpdatedText" xml:space="preserve">
-    <value>Data was last updated on {0}</value>
+    <value>Data ({0}) was last updated on {1} or earlier</value>
   </data>
   <data name="Locations_UpdateButtonText" xml:space="preserve">
     <value>Refresh</value>

--- a/src/Vahti.Mobile/Vahti.Mobile.Forms/Views/LocationListPage.xaml
+++ b/src/Vahti.Mobile/Vahti.Mobile.Forms/Views/LocationListPage.xaml
@@ -136,10 +136,20 @@
 
      
         <StackLayout Margin="0,0,0,0" Padding="8" BackgroundColor="{DynamicResource ThemeBackground}">
-            <StackLayout Orientation="Horizontal" Margin="0,4,0,4" IsVisible="false">
-                <Label Text="{x:Static fonticons:FontIcons.FontAwesomeExclamation}" Style="{StaticResource StatusTextLabelStyle}" FontFamily="{StaticResource FontAwesomeSolid}" VerticalOptions="Center"/>
-                <Label Text="{Binding LastUpdated}" IsVisible="{Binding IsOldData}" Style="{StaticResource StatusTextLabelStyle}" VerticalTextAlignment="Center" />
-            </StackLayout>
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto" IsVisible="{Binding IsOldData}">
+                <Label 
+                    Text="{x:Static fonticons:FontIcons.FontAwesomeExclamation}" 
+                    Style="{StaticResource StatusTextLabelStyle}" 
+                    FontFamily="{StaticResource FontAwesomeSolid}" 
+                    VerticalOptions="Center"
+                    Grid.Column="0"/>
+                <Label 
+                    Text="{Binding LastUpdated}" 
+                    IsVisible="{Binding IsOldData}" 
+                    Style="{StaticResource StatusTextLabelStyle}" 
+                    VerticalTextAlignment="Center"
+                    Grid.Column="1"/>
+            </Grid>
 
             <RefreshView
              Command="{Binding RefreshListCommand}"


### PR DESCRIPTION
Showing the notification was disabled in past, but now it's activated again. Notification is also improved to include names of all locations having old data, and it shows timestamp of most recently updated one.
![image](https://user-images.githubusercontent.com/53601355/139573004-2765a2fa-e4e5-41a7-a262-8732fd3a5d9b.png)
