### PR TITLE
Fix Azure pipeline issues related to Android and iOS builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,9 +156,9 @@ jobs:
   - task: CmdLine@2
     inputs:
       script: '/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"'
-  - task: CmdLine@2
-    inputs:
-      script: '/bin/bash -c "sudo xcode-select --switch /Applications/Xcode_11.4.app/Contents/Developer"'
+  #- task: CmdLine@2
+  #  inputs:
+  #    script: '/bin/bash -c "sudo xcode-select --switch /Applications/Xcode_11.4.app/Contents/Developer"'
   - task: XamariniOS@2
     displayName: Build iOS app
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,7 +155,7 @@ jobs:
       artifactName: 'apk'      
   - task: CmdLine@2
     inputs:
-      script: '/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"'
+      script: '/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_12_15"'
   - task: CmdLine@2
     inputs:
       script: '/bin/bash -c "sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer"'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,7 +155,7 @@ jobs:
       artifactName: 'apk'      
   - task: CmdLine@2
     inputs:
-      script: '/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_12_15"'
+      script: '/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_12_12"'
   - task: CmdLine@2
     inputs:
       script: '/bin/bash -c "sudo xcode-select --switch /Applications/Xcode_13.2.1.app/Contents/Developer"'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,6 +118,10 @@ jobs:
     inputs:
       script: 'cp App.template.config App.config' 
       workingDirectory: 'src/Vahti.Mobile/Vahti.Mobile.Forms'      
+  - task: CmdLine@2
+    displayName: XA5104 Workaround
+    inputs:
+      script: '${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.4.7075529"'
   - task: XamarinAndroid@1
     displayName: Build Android app
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,7 +158,7 @@ jobs:
       script: '/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_12_15"'
   - task: CmdLine@2
     inputs:
-      script: '/bin/bash -c "sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer"'
+      script: '/bin/bash -c "sudo xcode-select --switch /Applications/Xcode_13.2.1.app/Contents/Developer"'
   - task: XamariniOS@2
     displayName: Build iOS app
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,9 +156,9 @@ jobs:
   - task: CmdLine@2
     inputs:
       script: '/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"'
-  #- task: CmdLine@2
-  #  inputs:
-  #    script: '/bin/bash -c "sudo xcode-select --switch /Applications/Xcode_11.4.app/Contents/Developer"'
+  - task: CmdLine@2
+    inputs:
+      script: '/bin/bash -c "sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer"'
   - task: XamariniOS@2
     displayName: Build iOS app
     inputs:


### PR DESCRIPTION
Azure pipelines fail due to Android NDK not found. It seems to be a known issue:
[https://github.com/xamarin/xamarin-android/issues/7233](https://github.com/xamarin/xamarin-android/issues/7233)

Workaround is to install NDK before building Android App.

Also Xcode and Xamarin SDK version had to be updated for iOS build to succeed.